### PR TITLE
Use jQuery to make tests working in PhantomJs

### DIFF
--- a/lib/gh-interface.js
+++ b/lib/gh-interface.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 
 export function showTooltip($target, msg) {
   if (!$target.hasClass('tooltipped')) {
@@ -16,7 +17,6 @@ function getUserName() {
 }
 
 export function showNotification() {
-  const containerEl = document.getElementById('js-flash-container');
   const username = getUserName();
 
   const html = `<div class="flash flash-full">
@@ -27,5 +27,5 @@ export function showNotification() {
     </div>
   </div>`;
 
-  containerEl.insertAdjacentHTML('beforeend', html);
+  $('#js-flash-container').append(html);
 }


### PR DESCRIPTION
The problem was this native function [insertAdjacentHTML](https://github.com/OctoLinker/browser-extension/blob/b0bdcd077016d0ddf828e28f61b1404583c47f0c/lib/gh-interface.js#L30) which seems to be not available in PhantomJS. 