### PR TITLE
Allow for exported imports.

### DIFF
--- a/lib/plugins/javascript/index.js
+++ b/lib/plugins/javascript/index.js
@@ -1,4 +1,4 @@
-import { REQUIRE, REQUIRE_RESOLVE, IMPORT } from '../../../packages/helper-grammar-regex-collection/index.js';
+import { REQUIRE, REQUIRE_RESOLVE, IMPORT, EXPORT } from '../../../packages/helper-grammar-regex-collection/index.js';
 import insertLink from '../../insert-link';
 import preset from '../../pattern-preset';
 
@@ -9,7 +9,7 @@ export default class JavaScript {
   }
 
   parseBlob(blob) {
-    [REQUIRE, REQUIRE_RESOLVE, IMPORT].forEach((regex) => {
+    [REQUIRE, REQUIRE_RESOLVE, IMPORT, EXPORT].forEach((regex) => {
       insertLink(blob.el, regex, {
         resolver: 'javascriptUniversal',
         target: '$1',

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -1,11 +1,13 @@
 const REQUIRE = /require(?:\s|\()(['"][^'"\s]+['"])\)?/g;
 const REQUIRE_RESOLVE = /require(?:.resolve)(?:\s|\()(['"][^'"\s]+['"])\)?/g;
 const IMPORT = /import [\r\n\s\w{},*\$]*(?: from )?(['"][^'"\s]+['"])/g;
+const EXPORT = /export [\r\n\s\w{},*\$]*(?: from )(['"][^'"\s]+['"])/g;
 const GEM = /gem (['"][^'"\s]+['"])/g;
 
 export {
   REQUIRE,
   REQUIRE_RESOLVE,
   IMPORT,
+  EXPORT,
   GEM,
 };

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import {
   IMPORT,
+  EXPORT,
   REQUIRE,
   REQUIRE_RESOLVE,
   GEM,
@@ -35,6 +36,21 @@ const fixtures = {
       // TODO tweak IMPORT regexp so that invalid statements are not matched
       // 'import foo "foo"',
       // 'import from "foo"',
+    ],
+  },
+  EXPORT: {
+    regex: EXPORT,
+    valid: [
+      'export * from "foo"',
+      'export { foo, bar } from "foo"',
+      'export { foo as bar} from "foo"',
+      'export { foo, bar as baz } from "foo"',
+      'export {\nbar } from "foo"',
+      'export { bar\n } from "foo"',
+      'export { \nbar\n } from "foo"',
+    ],
+    invalid: [
+      'export * from "fo o"'
     ],
   },
   REQUIRE: {


### PR DESCRIPTION
The module spec allows for the following:

```js
export * from "foo";
export {foo, bar} from "foo";
export {foo as bar} from "foo";
```

Reference:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#Syntax
 - http://www.ecma-international.org/ecma-262/6.0/#sec-exports

Fixes #78