### PR TITLE
Template strings in data attr object

### DIFF
--- a/lib/insert-link.js
+++ b/lib/insert-link.js
@@ -23,7 +23,7 @@ function createLinkElement(text, dataAttr = {}) {
 }
 
 function getCaptureGroupIndex(captureGroup) {
-  const match = captureGroup.match(/^\$([0-9]+)/);
+  const match = captureGroup.match(/\$([0-9]+)/);
   if (!match || !match[1]) {
     return undefined;
   }
@@ -37,7 +37,7 @@ function getCaptureGroupValue(match, captureGroup) {
     return undefined;
   }
 
-  return match[index];
+  return captureGroup.replace(new RegExp('\\$' + index, 'g'), match[index]);
 }
 
 function buildDataAttr(data, match) {

--- a/test/insert-link.test.js
+++ b/test/insert-link.test.js
@@ -62,6 +62,15 @@ describe('helper-replace-keywords', () => {
     });
   });
 
+  it('adds the given data-* attributes', () => {
+    const { input } = createExpectation('foo <span><i>"</i>$0foo$0<i>"</i></span>');
+    const options = { value: 'go/$1.txt' };
+
+    assert.deepEqual($('.octo-linker-link', helper(input, options)).data(), {
+      value: 'go/foo.txt',
+    });
+  });
+
   it('wraps the second regex match', () => {
     const options = { value: '$2', xx: 'yy' };
     const { input, output } = createExpectation('foo <i>"</i>bar<i>"</i> <i>"</i>$0baz$0<i>"</i>', options);


### PR DESCRIPTION
This allows you to specify place holders in the data-attr object. These place holders are replaced with the associated match from the RegExp.

```js
    insertLink(blob.el, HOMEBREW, {
      resolver: 'relativeFile',
      path: blob.path,
      target: '$1.rb',
    });
```