### PR TITLE
Use <a href> instead of <span>, with 302 redirection for liveResolverQuery urls

### DIFF
--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -58,6 +58,8 @@ function onClick(event) {
     const newWindow = (event.metaKey || event.ctrlKey || event.which === 2);
     openUrl((res || {}).url || url, newWindow);
   });
+
+  return false;
 }
 
 export default function () {

--- a/lib/insert-link.js
+++ b/lib/insert-link.js
@@ -4,7 +4,7 @@ import findAndReplaceDOMText from 'findandreplacedomtext';
 const CLASS_NAME = 'octo-linker-link';
 
 function createLinkElement(text, dataAttr = {}) {
-  const linkEl = document.createElement('span');
+  const linkEl = document.createElement('a');
 
   // Set link text
   linkEl.innerHTML = text;

--- a/lib/insert-link.js
+++ b/lib/insert-link.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import findAndReplaceDOMText from 'findandreplacedomtext';
+import liveResolverQuery from './resolver/live-resolver-query.js';
 
 const CLASS_NAME = 'octo-linker-link';
 
@@ -17,6 +18,12 @@ function createLinkElement(text, dataAttr = {}) {
     if (dataAttr.hasOwnProperty(key)) {
       linkEl.dataset[key] = dataAttr[key];
     }
+  }
+
+  if (dataAttr.resolver == 'liveResolverQuery') {
+    const type = dataAttr.type;
+    const target = dataAttr.target;
+    linkEl.href = liveResolverQuery({type, target}, true).url;
   }
 
   return linkEl;

--- a/lib/resolver/live-resolver-query.js
+++ b/lib/resolver/live-resolver-query.js
@@ -1,6 +1,6 @@
-export default function ({ type, target }) {
+export default function ({ type, target }, redirect=false) {
   return {
-    url: `https://githublinker.herokuapp.com/q/${type}/${target}`,
+    url: `https://githublinker.herokuapp.com/q/${type}/${target}` + (redirect ? '?redirect=1' : ''),
     method: 'GET',
   };
 }

--- a/test/insert-link.test.js
+++ b/test/insert-link.test.js
@@ -19,9 +19,9 @@ describe('helper-replace-keywords', () => {
       dataAttributes += ` data-${key}="${value}"`;
     }
 
-    const start = `<span class="octo-linker-link"${dataAttributes}>`;
+    const start = `<a class="octo-linker-link"${dataAttributes}>`;
     const input = el.replace(/\$0/g, '');
-    const output = el.replace('$0', start).replace('$0', '</span>');
+    const output = el.replace('$0', start).replace('$0', '</a>');
 
     return {
       input,


### PR DESCRIPTION
This depends on https://github.com/OctoLinker/live-resolver/pull/12 being merged.

As discussed in https://github.com/OctoLinker/browser-extension/issues/49#issuecomment-137948995.

This is a proof-of-concept and may need to be refined to handle error/edge cases.
