### PR TITLE
Use currentTarget for click handler event.

### DIFF
--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -35,8 +35,8 @@ function getResolverUrls(dataAttr) {
 }
 
 function onClick(event) {
-  const dataAttr = event.target.dataset;
-  const $target = $(event.target);
+  const dataAttr = event.currentTarget.dataset;
+  const $target = $(event.currentTarget);
 
   showTooltip($target, PROCESS);
 


### PR DESCRIPTION
Happy Memorial Day!

This is related to item #88 

Using `currentTarget` in the click handler over `target` ensures that even if [other extensions](https://github.com/Nuclides/github-highlight-selected) change the DOM, we still get what we want.