### PR TITLE
Build chrome/app.js with source map

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -4,4 +4,4 @@ set -e
 NPM_BIN="$(npm bin)";
 cd "$(dirname "$0")/.."
 
-"$NPM_BIN/browserify" ./lib/app.js -t babelify --outfile ./chrome/app.js
+"$NPM_BIN/browserify" --debug ./lib/app.js -t babelify --outfile ./chrome/app.js

--- a/scripts/watch-build
+++ b/scripts/watch-build
@@ -4,4 +4,4 @@ set -e
 NPM_BIN="$(npm bin)";
 cd "$(dirname "$0")/.."
 
-"$NPM_BIN/watchify" ./lib/app.js -t babelify --outfile ./chrome/app.js
+"$NPM_BIN/watchify" --debug ./lib/app.js -t babelify --outfile ./chrome/app.js


### PR DESCRIPTION
This lets developers debug the original code, rather than the compiled
output. Here's a before/after of the debugging experience:

Before:
<img width="1554" alt="before" src="https://cloud.githubusercontent.com/assets/6473925/15878498/5f5acba4-2ce9-11e6-86ed-4262be6d769a.png">

After:
<img width="1554" alt="after" src="https://cloud.githubusercontent.com/assets/6473925/15878502/682a2720-2ce9-11e6-94e2-f92ed2ecd169.png">

Note that this increases the size of chrome/app.js by roughly 1 MB. If that's a problem, We could use an [external source map](https://github.com/substack/node-browserify#external-source-maps) instead, and then figure out how not to include that in the published extension.
