### PR TITLE
postinstall: overwrite pre-commit hook if needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "main": "lib/app.js",
   "scripts": {
-    "postinstall": "ln -s ./scripts/hooks/pre-commit .git/hooks/pre-commit",
+    "postinstall": "ln -sf ./scripts/hooks/pre-commit .git/hooks/pre-commit",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test": "karma start",


### PR DESCRIPTION
This lets you `npm install` multiple times without issue.

(from https://github.com/OctoLinker/browser-extension/pull/97#issuecomment-225069078)