### PR TITLE
Plugins located in lib/plugins will be auto-loaded

### DIFF
--- a/lib/load-plugins.js
+++ b/lib/load-plugins.js
@@ -1,0 +1,14 @@
+
+// Load all plugins from /lib/plugins/*/index.js.
+// For more information about dynamic require see
+// https://webpack.github.io/docs/context.html
+
+export default function loadPlugins() {
+  function requireAll(requireContext) {
+    return requireContext.keys().map((pluginPath) => {
+      return requireContext(pluginPath).default;
+    });
+  }
+
+  return requireAll(require.context('./plugins', true, /\/index\.js$/));
+}

--- a/lib/octo-linker.js
+++ b/lib/octo-linker.js
@@ -2,15 +2,10 @@ import injection from 'github-injection';
 import notification from './notification';
 import BlobReader from '../packages/blob-reader';
 import clickHandler from './click-handler';
-import PluginManager from './plugin-manager.js';
+import Plugins from './plugin-manager.js';
 import debugMode from './debug-mode.js';
-import JavaScript from './plugins/javascript';
-import NpmManifest from './plugins/npm-manifest';
-import BowerManifest from './plugins/bower-manifest';
-import GemfileManifest from './plugins/gemfile-manifest';
-import HomebrewManifest from './plugins/homebrew-manifest';
-import ComposerManifest from './plugins/composer-manifest';
-import Ruby from './plugins/ruby';
+import loadPlugins from './load-plugins';
+
 
 function initialize(self) {
   debugMode(false);
@@ -18,15 +13,7 @@ function initialize(self) {
   notification();
 
   self._blobReader = new BlobReader();
-  self._pluginManager = new PluginManager([
-    JavaScript,
-    NpmManifest,
-    BowerManifest,
-    GemfileManifest,
-    HomebrewManifest,
-    ComposerManifest,
-    Ruby,
-  ]);
+  self._pluginManager = new Plugins(loadPlugins());
 }
 
 function run(self) {

--- a/test/load-plugins.test.js
+++ b/test/load-plugins.test.js
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import loadPlugins from '../lib/load-plugins.js';
+
+describe('load-plugins', () => {
+  it('returns an array of functions', () => {
+    const plugins = loadPlugins();
+
+    assert(Array.isArray(plugins));
+
+    plugins.forEach((func) => {
+      assert.equal(typeof func, 'function');
+    });
+  });
+});


### PR DESCRIPTION
Based on the feedback from @josephfrazier in https://github.com/OctoLinker/browser-extension/issues/86, this PR adds an auto-loader which loads all plugins located in `lib/plugins`. By that, a plugin developer doesn't have to think about import the plugin manually. 