### PR TITLE
Upload builds to GitHub releage page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,14 @@ node_js:
   - 4.0
   - 4
   - 6
+after_success:
+  - npm run chrome-pack
+  - npm run firefox-pack
+deploy:
+  provider: releases
+  api_key: "$GH_DEPLOY"
+  file_glob: true
+  file: "out/*.zip"
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
Every time when a new git tag is pushed to master travis will automatically build and upload the browser builds to the corresponding git tag on the release page