### PR TITLE
Don't test Node v4.0 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - 4.0
   - 4
   - 6
 after_success:


### PR DESCRIPTION
Travis already tests Node v4 at the latest minor/patch version.