### PR TITLE
Support Homebrew-Cask dependencies/conflicts

### DIFF
--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -3,7 +3,11 @@ const REQUIRE_RESOLVE = /require(?:.resolve)(?:\s|\()(['"][^'"\s]+['"])\)?/g;
 const IMPORT = /import [\r\n\s\w{},*\$]*(?: from )?(['"][^'"\s]+['"])/g;
 const EXPORT = /export [\r\n\s\w{},*\$]*(?: from )(['"][^'"\s]+['"])/g;
 const GEM = /gem (['"][^'"\s]+['"])/g;
-const HOMEBREW = /(?:depends_on|conflicts_with) (['"][^'"\s]+['"])/g;
+// TODO support `formula:` as well. See
+// https://github.com/caskroom/homebrew-cask/blob/714bd04bebd195500843dbb2cdbef21d65ff8852/doc/cask_language_reference/stanzas/depends_on.md#depends_on-formula
+// Ideally, we'd have a way of knowing which Homebrew tap is referred to, but
+// we could just use https://github.com/Homebrew/homebrew-core/
+const HOMEBREW = /(?:depends_on|conflicts_with)(?: cask:)? (['"][^'"\s]+['"])/g;
 
 export {
   REQUIRE,

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -116,6 +116,10 @@ const fixtures = {
       ['depends_on \'foo\'', ['\'foo\'']],
       'conflicts_with "foo"',
       ['conflicts_with \'foo\'', ['\'foo\'']],
+      'depends_on cask: "foo"',
+      ['depends_on cask: \'foo\'', ['\'foo\'']],
+      'conflicts_with cask: "foo"',
+      ['conflicts_with cask: \'foo\'', ['\'foo\'']],
     ],
     // These probably aren't actually invalid, but
     // https://github.com/Homebrew/homebrew-core/ has no occurences of multiple


### PR DESCRIPTION
This is only for `cask:` dependencies/conflicts. Here's an example:

https://github.com/caskroom/homebrew-cask/blob/d58e2c0724fe782a4ba18383e3dc387c59d63567/Casks/lazarus.rb#L11