### PR TITLE
Travis: cache node_modules across builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: node_js
 node_js:
   - 4
   - 6
+cache:
+  directories:
+    - node_modules
 after_success:
   - npm run package-all
 deploy:


### PR DESCRIPTION
This should reduce build times by about half, since `npm install` won't
need to install anything most of the time. Here are some log lines
showing how long `npm install` currently takes:

https://travis-ci.org/OctoLinker/browser-extension/jobs/144849130#L147
https://travis-ci.org/OctoLinker/browser-extension/jobs/144849129#L147

Here is the Travis documentation about the cache feature:

https://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies