### PR TITLE
Link the `browser` field in package.json

### DIFF
--- a/lib/plugins/npm-manifest/index.js
+++ b/lib/plugins/npm-manifest/index.js
@@ -38,6 +38,7 @@ export default class NpmManifest {
       '$.optionalDependencies': linkDependency,
       '$.main': linkFile,
       '$.bin': linkFile,
+      '$.browser': linkFile,
     });
   }
 }


### PR DESCRIPTION
Example: https://github.com/matthew-andrews/isomorphic-fetch/blob/89c7e70c313d4965f05ac8f0f3a2fcf239c82876/package.json#L5

Spec: https://github.com/defunctzombie/package-browser-field-spec#spec