### PR TITLE
Link the `bin` field in package.json

### DIFF
--- a/lib/plugins/npm-manifest/index.js
+++ b/lib/plugins/npm-manifest/index.js
@@ -37,6 +37,7 @@ export default class NpmManifest {
       '$.peerDependencies': linkDependency,
       '$.optionalDependencies': linkDependency,
       '$.main': linkFile,
+      '$.bin': linkFile,
     });
   }
 }


### PR DESCRIPTION
Example: https://github.com/substack/node-browserify/blob/071642ad9cbb44cb530d43edfac17c5077a9442c/package.json#L7

Spec: https://docs.npmjs.com/files/package.json#bin