### PR TITLE
Add Typescript support

### DIFF
--- a/lib/insert-link.js
+++ b/lib/insert-link.js
@@ -78,6 +78,18 @@ function getIndexes(portion, entireMatch, matchValue) {
   };
 }
 
+function wrapClosestElement(node, dataAttrObject, matchValue) {
+  let currentNode = node;
+
+  while (!currentNode.textContent.includes(matchValue)) {
+    currentNode = currentNode.parentNode;
+  }
+
+  if (currentNode) {
+    $(currentNode).wrap(createLinkElement('', dataAttrObject));
+  }
+}
+
 function replace(portion, match, dataAttr, captureGroup) {
   const isAlreadyWrapped = portion.node.parentNode.classList.contains(CLASS_NAME);
 
@@ -95,14 +107,8 @@ function replace(portion, match, dataAttr, captureGroup) {
       return createLinkElement(portion.text, dataAttrObject);
     }
 
-    let node = portion.node;
-    while (!node.textContent.includes(matchValue)) {
-      node = node.parentNode;
-    }
-
-    if (node) {
-      $(node).wrap(createLinkElement('', dataAttrObject));
-    }
+    wrapClosestElement(node, dataAttrObject, matchValue);
+    return text;
   }
 
   return portion.text;

--- a/lib/insert-link.js
+++ b/lib/insert-link.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import findAndReplaceDOMText from 'findandreplacedomtext';
 
 const CLASS_NAME = 'octo-linker-link';
+const QUOTE_SIGNS = `"'`;
 
 function createLinkElement(text, dataAttr = {}) {
   const linkEl = document.createElement('a');
@@ -78,6 +79,16 @@ function getIndexes(portion, entireMatch, matchValue) {
   };
 }
 
+function getQuoteAtPos(str, pos) {
+  const sign = str.charAt(pos);
+
+  if (QUOTE_SIGNS.includes(sign)) {
+    return sign;
+  }
+
+  return '';
+}
+
 function wrapClosestElement(node, dataAttrObject, matchValue) {
   let currentNode = node;
 
@@ -90,28 +101,46 @@ function wrapClosestElement(node, dataAttrObject, matchValue) {
   }
 }
 
+function wrapsInnerString(text, matchValue, dataAttrObject) {
+  const parent = document.createElement('span');
+  const [leftSide] = text.split(matchValue);
+  const openingQuote = getQuoteAtPos(matchValue, 0);
+  const closingQuote = getQuoteAtPos(matchValue, matchValue.length - 1);
+  const linkText = matchValue.slice(openingQuote ? 1 : 0, closingQuote ? matchValue.length - 1 : undefined);
+
+  if (leftSide) parent.appendChild(document.createTextNode(leftSide));
+  if (openingQuote) parent.appendChild(document.createTextNode(openingQuote));
+  parent.appendChild(createLinkElement(linkText, dataAttrObject));
+  if (closingQuote) parent.appendChild(document.createTextNode(closingQuote));
+  return parent;
+}
+
 function replace(portion, match, dataAttr, captureGroup) {
-  const isAlreadyWrapped = portion.node.parentNode.classList.contains(CLASS_NAME);
+  const { text, node, indexInMatch } = portion;
+  const isAlreadyWrapped = node.parentNode.classList.contains(CLASS_NAME);
 
   if (isAlreadyWrapped) {
-    return portion.text;
+    return text;
   }
 
   const matchValue = getCaptureGroupValue(match, captureGroup);
+  const dataAttrObject = buildDataAttr(dataAttr, match);
+
+  if (text === matchValue) {
+    return wrapsInnerString(text, matchValue, dataAttrObject);
+  }
+
   const { valueStartPos, valueEndPos, portionEndPos } = getIndexes(portion, match[0], matchValue);
-
-  if (valueStartPos === portion.indexInMatch) {
-    const dataAttrObject = buildDataAttr(dataAttr, match);
-
+  if (valueStartPos === indexInMatch) {
     if (portionEndPos === valueEndPos) {
-      return createLinkElement(portion.text, dataAttrObject);
+      return createLinkElement(text, dataAttrObject);
     }
 
     wrapClosestElement(node, dataAttrObject, matchValue);
     return text;
   }
 
-  return portion.text;
+  return text;
 }
 
 export default function (el, regex, mapping, captureGroup = '$1') {

--- a/lib/insert-link.js
+++ b/lib/insert-link.js
@@ -126,7 +126,7 @@ function replace(portion, match, dataAttr, captureGroup) {
   const matchValue = getCaptureGroupValue(match, captureGroup);
   const dataAttrObject = buildDataAttr(dataAttr, match);
 
-  if (text === matchValue) {
+  if (node.textContent.includes(matchValue)) {
     return wrapsInnerString(text, matchValue, dataAttrObject);
   }
 

--- a/lib/plugins/typescript/index.js
+++ b/lib/plugins/typescript/index.js
@@ -1,0 +1,7 @@
+import JavaScript from '../javascript';
+
+export default class TypeScript extends JavaScript {
+  getPattern() {
+    return ['.ts'];
+  }
+}

--- a/lib/plugins/typescript/index.js
+++ b/lib/plugins/typescript/index.js
@@ -1,7 +1,19 @@
 import JavaScript from '../javascript';
+import { TYPESCRIPT_REFERENCE } from '../../../packages/helper-grammar-regex-collection/index.js';
+import insertLink from '../../insert-link';
 
 export default class TypeScript extends JavaScript {
   getPattern() {
     return ['.ts'];
+  }
+
+  parseBlob(blob) {
+    super.parseBlob(blob);
+
+    insertLink(blob.el, TYPESCRIPT_REFERENCE, {
+      resolver: 'relativeFile',
+      target: '$1',
+      path: blob.path,
+    });
   }
 }

--- a/lib/resolver/javascript-file.js
+++ b/lib/resolver/javascript-file.js
@@ -2,7 +2,7 @@ import { join, dirname, extname } from 'path';
 
 export default function ({ path, target }) {
   const list = [];
-  const extName = ['.js', '.jsx', '.json'];
+  const extName = ['.js', '.jsx', '.ts', '.tsx', '.json'];
   let basePath = join(dirname(path), target);
   const pathExt = extname(path);
   const fileExt = extname(basePath);

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -8,6 +8,7 @@ const GEM = /gem (['"][^'"\s]+['"])/g;
 // Ideally, we'd have a way of knowing which Homebrew tap is referred to, but
 // we could just use https://github.com/Homebrew/homebrew-core/
 const HOMEBREW = /(?:depends_on|conflicts_with)(?: cask:)? (['"][^'"\s]+['"])/g;
+const TYPESCRIPT_REFERENCE = /\/{3}\s?<reference path=(['"][^'"\s]+['"])/g;
 
 export {
   REQUIRE,
@@ -16,4 +17,5 @@ export {
   EXPORT,
   GEM,
   HOMEBREW,
+  TYPESCRIPT_REFERENCE,
 };

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -117,6 +117,15 @@ const fixtures = {
       'conflicts_with     "foo"',
     ],
   },
+  TYPESCRIPT_REFERENCE: {
+    valid: [
+      '/// <reference path="foo" />',
+      '///<reference path="foo" />',
+    ],
+    invalid: [
+      '// <reference path="foo" />',
+    ],
+  },
 };
 
 describe('helper-grammar-regex-collection', () => {

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -1,16 +1,8 @@
 import assert from 'assert';
-import {
-  IMPORT,
-  EXPORT,
-  REQUIRE,
-  REQUIRE_RESOLVE,
-  GEM,
-  HOMEBREW,
-} from './index.js';
+import * as REGEX from './index.js';
 
 const fixtures = {
   IMPORT: {
-    regex: IMPORT,
     valid: [
       'import foo from "foo"',
       'import _ from "foo"',
@@ -40,7 +32,6 @@ const fixtures = {
     ],
   },
   EXPORT: {
-    regex: EXPORT,
     valid: [
       'export * from "foo"',
       'export { foo, bar } from "foo"',
@@ -55,7 +46,6 @@ const fixtures = {
     ],
   },
   REQUIRE: {
-    regex: REQUIRE,
     valid: [
       'require("foo")',
       'var foo = require("foo")',
@@ -83,7 +73,6 @@ const fixtures = {
     ],
   },
   REQUIRE_RESOLVE: {
-    regex: REQUIRE_RESOLVE,
     valid: [
       'require.resolve "foo"',
       'require.resolve("foo")',
@@ -100,7 +89,6 @@ const fixtures = {
     ],
   },
   GEM: {
-    regex: GEM,
     valid: [
       'gem "foo"',
       ['gem \'foo\'', ['\'foo\'']],
@@ -110,7 +98,6 @@ const fixtures = {
     ],
   },
   HOMEBREW: {
-    regex: HOMEBREW,
     valid: [
       'depends_on "foo"',
       ['depends_on \'foo\'', ['\'foo\'']],
@@ -134,7 +121,8 @@ const fixtures = {
 
 describe('helper-grammar-regex-collection', () => {
   Object.keys(fixtures).forEach((grammar) => {
-    const { regex, valid, invalid } = fixtures[grammar];
+    const { valid, invalid } = fixtures[grammar];
+    const regex = REGEX[grammar];
 
     beforeEach(() => {
       regex.lastIndex = 0;

--- a/test/insert-link.test.js
+++ b/test/insert-link.test.js
@@ -82,8 +82,16 @@ describe('helper-replace-keywords', () => {
 
   it('wraps a single string', () => {
     const regex = /(bar)/;
-    const { input } = createExpectation(`foo bar`);
-    const { output } = createExpectation(`foo <span>$0bar$0</span>`);
+    const { input } = createExpectation(`foo bar baz`);
+    const { output } = createExpectation(`foo <span>$0bar$0</span> baz`);
+
+    assert.equal(helper(input, regex).innerHTML, output);
+  });
+
+  it('wraps a multiple strings', () => {
+    const regex = /foo (bar)/;
+    const { input } = createExpectation(`foo bar baz`);
+    const { output } = createExpectation(`<span>foo $0bar$0</span> baz`);
 
     assert.equal(helper(input, regex).innerHTML, output);
   });

--- a/test/insert-link.test.js
+++ b/test/insert-link.test.js
@@ -3,7 +3,9 @@ import $ from 'jquery';
 import insertLink from '../lib/insert-link.js';
 
 describe('helper-replace-keywords', () => {
-  function helper(html, options = { value: '$1' }, regex = /foo ("\w+")/, replaceIndex = '$1') {
+  const DEFAULT_REGEX = /foo ("\w+")/;
+
+  function helper(html, regex = DEFAULT_REGEX, options = {}, replaceIndex = '$1') {
     const el = document.createElement('div');
     el.innerHTML = html;
 
@@ -29,22 +31,61 @@ describe('helper-replace-keywords', () => {
     };
   }
 
-  function simpleAssert(el, dataAttr) {
-    const { input, output } = createExpectation(el, dataAttr);
+  function simpleAssert(el) {
+    const { input, output } = createExpectation(el);
 
     assert.equal(helper(input).innerHTML, output);
   }
 
   it('wraps the elements based on their char position which is specified in the kewords map', () => {
-    simpleAssert('foo <span><i>"</i>$0foo$0<i>"</i></span>', { value: 'foo' });
+    simpleAssert('foo <span><i>"</i>$0foo$0<i>"</i></span>');
   });
 
   it('wraps the parent element when keyword is divided', () => {
-    simpleAssert('foo $0<span><i>"</i><span>fo</span>o<i>"</i></span>$0', { value: 'foo' });
+    simpleAssert('foo $0<span><i>"</i><span>fo</span>o<i>"</i></span>$0');
   });
 
   it('wraps a neasted element', () => {
-    simpleAssert('foo <div><span><i>"</i>$0foo$0<i>"</i></span></div>', { value: 'foo' });
+    simpleAssert('foo <div><span><i>"</i>$0foo$0<i>"</i></span></div>');
+  });
+
+  it('wraps double quotes', () => {
+    const { input } = createExpectation('foo <span>"foo"</span>');
+    const { output } = createExpectation('foo <span><span>"$0foo$0"</span></span>');
+
+    assert.equal(helper(input).innerHTML, output);
+  });
+
+  it('wraps single quotes', () => {
+    const regex = /foo ('\w+')/;
+    const { input } = createExpectation(`foo <span>'foo'</span>`);
+    const { output } = createExpectation(`foo <span><span>'$0foo$0'</span></span>`);
+
+    assert.equal(helper(input, regex).innerHTML, output);
+  });
+
+  it('wraps mixed quotes', () => {
+    const regex = /foo ('\w+")/;
+    const { input } = createExpectation(`foo <span>'foo"</span>`);
+    const { output } = createExpectation(`foo <span><span>'$0foo$0"</span></span>`);
+
+    assert.equal(helper(input, regex).innerHTML, output);
+  });
+
+  it('wraps a single word', () => {
+    const regex = /foo (\w+)/;
+    const { input } = createExpectation(`foo <span>bar</span>`);
+    const { output } = createExpectation(`foo <span><span>$0bar$0</span></span>`);
+
+    assert.equal(helper(input, regex).innerHTML, output);
+  });
+
+  it('wraps a single string', () => {
+    const regex = /(bar)/;
+    const { input } = createExpectation(`foo bar`);
+    const { output } = createExpectation(`foo <span>$0bar$0</span>`);
+
+    assert.equal(helper(input, regex).innerHTML, output);
   });
 
   it('wraps the element once', () => {
@@ -56,7 +97,7 @@ describe('helper-replace-keywords', () => {
     const { input } = createExpectation('foo <span><i>"</i>$0foo$0<i>"</i></span>');
     const options = { value: '$1', bar: 'baz' };
 
-    assert.deepEqual($('.octo-linker-link', helper(input, options)).data(), {
+    assert.deepEqual($('.octo-linker-link', helper(input, DEFAULT_REGEX, options)).data(), {
       value: 'foo',
       bar: 'baz',
     });
@@ -66,7 +107,7 @@ describe('helper-replace-keywords', () => {
     const { input } = createExpectation('foo <span><i>"</i>$0foo$0<i>"</i></span>');
     const options = { value: 'go/$1.txt' };
 
-    assert.deepEqual($('.octo-linker-link', helper(input, options)).data(), {
+    assert.deepEqual($('.octo-linker-link', helper(input, DEFAULT_REGEX, options)).data(), {
       value: 'go/foo.txt',
     });
   });
@@ -76,6 +117,6 @@ describe('helper-replace-keywords', () => {
     const { input, output } = createExpectation('foo <i>"</i>bar<i>"</i> <i>"</i>$0baz$0<i>"</i>', options);
     const regex = /foo ("\w+") ("\w+")/;
 
-    assert.equal(helper(input, options, regex, '$2').innerHTML, output.replace('$2', 'baz'));
+    assert.equal(helper(input, regex, options, '$2').innerHTML, output.replace('$2', 'baz'));
   });
 });


### PR DESCRIPTION
![screen shot 2016-07-30 at 01 15 55](https://cloud.githubusercontent.com/assets/1393946/17265909/4bc02318-55f3-11e6-98f9-4e95615921c8.png)

This PR adds support for TypeScript `import` and `require` statements. Also it allows to click on the path specified in a ts reference tag see #67.

In order to make this happen I had to tweak the `insert-link`, because the html structure for ts files is a bit different than for javascript. 

@josephfrazier  can you also do a quick sanity check with some TS project, please. That would be great. 
