### PR TITLE
Remove HTML files from GH stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+packages/blob-reader/fixtures/* linguist-documentation


### PR DESCRIPTION
The stats report for the repository aren't correct, because of the massiv fixtures files for the blob reader. To fix this, I added an entry to `.gitattributes` to remove thoese files from the stats. For more details go to https://github.com/github/linguist#overrides

![screen shot 2016-07-29 at 23 53 22](https://cloud.githubusercontent.com/assets/1393946/17264581/3ce4306a-55e8-11e6-96d8-7632320fe827.png)


