### PR TITLE
homebrew: use homebrew-core for fallback link

### DIFF
--- a/lib/plugins/homebrew-manifest/index.js
+++ b/lib/plugins/homebrew-manifest/index.js
@@ -20,7 +20,7 @@ export default class HomebrewManifest {
 
   parseBlob(blob) {
     insertLink(blob.el, HOMEBREW, {
-      resolver: 'relativeFile',
+      resolver: 'homebrewFile',
       path: blob.path,
       target: '$1.rb',
     });

--- a/lib/resolver/homebrew-file.js
+++ b/lib/resolver/homebrew-file.js
@@ -1,0 +1,8 @@
+import relativeFile from './relative-file.js';
+
+export default function ({ path, target }) {
+  return [
+    relativeFile({ path, target }),
+    'https://github.com/Homebrew/homebrew-core/blob/master/Formula/' + target,
+  ];
+}

--- a/lib/resolver/index.js
+++ b/lib/resolver/index.js
@@ -2,6 +2,7 @@ import liveResolverQuery from './live-resolver-query.js';
 import liveResolverPing from './live-resolver-ping.js';
 import relativeFile from './relative-file.js';
 import javascriptFile from './javascript-file.js';
+import homebrewFile from './homebrew-file.js';
 import gitUrl from './git-url.js';
 import githubShorthand from './github-shorthand.js';
 import javascriptUniversal from './javascript-universal.js';
@@ -12,6 +13,7 @@ export {
   liveResolverPing,
   relativeFile,
   javascriptFile,
+  homebrewFile,
   javascriptUniversal,
   gitUrl,
   githubShorthand,

--- a/test/resolver/homebrew-file.test.js
+++ b/test/resolver/homebrew-file.test.js
@@ -1,0 +1,17 @@
+import assert from 'assert';
+import homebrewFile from '../../lib/resolver/homebrew-file.js';
+
+describe('homebrew-file', () => {
+  it('resolves a dependency of a homebrew-science formula to both homebrew-science and homebrew-core', () => {
+    assert.deepEqual(
+      homebrewFile({
+        path: '/Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/octave.rb',
+        target: 'autoconf.rb',
+      }),
+      [
+        'https://github.com/Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/autoconf.rb',
+        'https://github.com/Homebrew/homebrew-core/blob/master/Formula/autoconf.rb',
+      ]
+    );
+  });
+});


### PR DESCRIPTION
This makes it so that homebrew formulae in other taps are properly
linked to their dependencies in the default tap. For example:

https://github.com/Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/octave.rb#L44

shows a dependency on autoconf, but the relativeFile resolver points to:

https://github.com/Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/autoconf.rb

which does not exist. Instead, use a new resolver to fall back to:

https://github.com/Homebrew/homebrew-core/blob/master/Formula/autoconf.rb