### PR TITLE
Synchronize assets/manifest.json version with package.json

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "OctoLinker",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "manifest_version": 2,
   "author": "Stefan Buck",
   "description": "",
@@ -14,7 +14,9 @@
     }
   },
   "background": {
-    "scripts": ["background.js"]
+    "scripts": [
+      "background.js"
+    ]
   },
   "content_scripts": [
     {
@@ -22,14 +24,18 @@
         "https://github.com/*",
         "https://gist.github.com/*"
       ],
-      "js": ["app.js"],
-      "css": ["style.css"],
+      "js": [
+        "app.js"
+      ],
+      "css": [
+        "style.css"
+      ],
       "run_at": "document_idle",
       "all_frames": false
     }
   ],
   "permissions": [
-      "https://github.com/",
-      "https://githublinker.herokuapp.com/"
+    "https://github.com/",
+    "https://githublinker.herokuapp.com/"
   ]
 }


### PR DESCRIPTION
This was done with `npm run version`, which normally happens as part of
`npm version` (see https://github.com/OctoLinker/browser-extension/pull/137)

It looks like the `json` command reformatted a couple of other fields,
but that should be a one-time thing, assuming we preserve the new
formatting with any manual changes we make in the future.

Once this is merged, we can tag it as `v4.2.0` and try the release again,
as described in https://github.com/OctoLinker/browser-extension/pull/137#issuecomment-236396330