### PR TITLE
Simplify external url handling by remove the ping resolver

### DIFF
--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import { showTooltip } from './gh-interface.js';
-import * as resolvers from './resolver/index.js';
 import { flattenAndCompact } from './utils/array';
 
 const SORRY = 'I\'m sorry, unable to resolve this link  😱';
@@ -45,7 +44,20 @@ function getResolverUrls(dataAttr) {
   const urls = resolverStrings.map((resolverName) => {
     const resolver = resolverHandlers.get(resolverName);
     if (resolver) {
-      return resolver(dataAttr);
+      return [].concat(resolver(dataAttr)).map((url) => {
+        if (!url) {
+          return null;
+        }
+
+        if (url.startsWith('https://github.com')) {
+          return url;
+        }
+
+        return {
+          url: `https://githublinker.herokuapp.com/ping?url=${url}`,
+          method: 'GET',
+        };
+      });
     }
   });
 
@@ -78,7 +90,7 @@ function onClick(event) {
   });
 }
 
-export default function () {
+export default function (resolvers) {
   $body.undelegate(LINK_SELECTOR, 'click', onClick);
   resolverHandlers.clear();
 

--- a/lib/octo-linker.js
+++ b/lib/octo-linker.js
@@ -1,6 +1,7 @@
 import injection from 'github-injection';
 import notification from './notification';
 import BlobReader from '../packages/blob-reader';
+import * as resolvers from './resolver/index.js';
 import clickHandler from './click-handler';
 import Plugins from './plugin-manager.js';
 import debugMode from './debug-mode.js';
@@ -9,7 +10,7 @@ import loadPlugins from './load-plugins';
 
 function initialize(self) {
   debugMode(false);
-  clickHandler();
+  clickHandler(resolvers);
   notification();
 
   self._blobReader = new BlobReader();

--- a/lib/resolver/index.js
+++ b/lib/resolver/index.js
@@ -1,5 +1,4 @@
 import liveResolverQuery from './live-resolver-query.js';
-import liveResolverPing from './live-resolver-ping.js';
 import relativeFile from './relative-file.js';
 import javascriptFile from './javascript-file.js';
 import gitUrl from './git-url.js';
@@ -9,7 +8,6 @@ import rubyUniversal from './ruby-universal.js';
 
 export {
   liveResolverQuery,
-  liveResolverPing,
   relativeFile,
   javascriptFile,
   javascriptUniversal,

--- a/lib/resolver/javascript-universal.js
+++ b/lib/resolver/javascript-universal.js
@@ -1,7 +1,6 @@
 import builtins from 'builtins';
 import javascriptFile from './javascript-file.js';
 import liveResolverQuery from './live-resolver-query.js';
-import liveResolverPing from './live-resolver-ping.js';
 
 function getTopModuleName(target) {
   const isScoped = target.startsWith('@');
@@ -15,9 +14,7 @@ export default function ({ path, target }) {
   const isBuildIn = builtins.indexOf(target) > -1;
 
   if (isBuildIn) {
-    return liveResolverPing({
-      target: `https://nodejs.org/api/${target}.html`,
-    });
+    return `https://nodejs.org/api/${target}.html`;
   }
 
   if (isPath) {

--- a/lib/resolver/live-resolver-ping.js
+++ b/lib/resolver/live-resolver-ping.js
@@ -1,6 +1,0 @@
-export default function ({ target }) {
-  return {
-    url: `https://githublinker.herokuapp.com/ping?url=${target}`,
-    method: 'GET',
-  };
-}

--- a/test/click-handler.test.js
+++ b/test/click-handler.test.js
@@ -1,52 +1,129 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import $ from 'jquery';
-import clickHandler, { registerHandler } from '../lib/click-handler';
+import clickHandler from '../lib/click-handler';
 
-describe.skip('helper-click-handler', () => {
+describe('click-handler', () => {
   const sandbox = sinon.sandbox.create();
-  const fooHandler = sandbox.stub();
-  const barHandler = sandbox.stub();
-  const $link = $('<div class="octo-linker-link" data-type="foo" data-bar="baz"></div>');
+  const $link = $('<div class="octo-linker-link" data-resolver="foo" data-bar="baz"></div>');
+  let resolvers;
+  let runtime;
 
   beforeEach(() => {
-    $('body').html($link);
-    clickHandler();
+    runtime = {
+      sendMessage: sandbox.stub(),
+      onMessage: {
+        addListener: sandbox.stub(),
+      },
+    };
+
+    window.chrome = {
+      runtime,
+    };
+
+    resolvers = {
+      foo: sandbox.stub(),
+      bar: sandbox.stub(),
+    };
+
+    $('body').append($link);
+    clickHandler(resolvers);
   });
 
   afterEach(() => {
     sandbox.reset();
-    $('body').off().empty();
+    $('body').off();
+    $link.remove();
   });
 
   after(() => {
     sandbox.restore();
   });
 
-  it('calls the corresponding handler', function () {
-    registerHandler('foo', fooHandler);
-    registerHandler('bar', barHandler);
+  it('does not attach more than one global click handler', () => {
+    clickHandler(resolvers);
+    clickHandler(resolvers);
     $link.click();
 
-    assert.equal(fooHandler.callCount, 1);
-    assert.equal(barHandler.callCount, 0);
+    assert.equal(resolvers.foo.callCount, 1);
   });
 
-  it('calls the corresponding handler with data-attr of the target', function () {
-    registerHandler('foo', fooHandler);
-    $link.click();
+  describe('on click', () => {
+    it('calls the corresponding resolver', () => {
+      $link.click();
 
-    assert.deepEqual(fooHandler.args[0][0], {
-      type: 'foo',
-      bar: 'baz',
+      assert.equal(resolvers.foo.callCount, 1);
+      assert.equal(resolvers.bar.callCount, 0);
+    });
+
+    it('calls the corresponding handler with data-attr of the target', () => {
+      $link.click();
+
+      assert.deepEqual(resolvers.foo.args[0][0], {
+        resolver: 'foo',
+        bar: 'baz',
+      });
     });
   });
 
-  it('does not attach more than one global click handler', function () {
-    clickHandler();
-    registerHandler('foo', fooHandler);
-    $link.click();
+  describe('request', () => {
+    it('sends a runtime message with urls to load', () => {
+      resolvers.foo.returns('https://github.com/foo');
+      $link.click();
 
-    assert.equal(fooHandler.callCount, 1);
+      assert.equal(runtime.sendMessage.callCount, 1);
+    });
+
+    it('passes an url string along the runtime message', () => {
+      resolvers.foo.returns('https://github.com/foo');
+      $link.click();
+
+      assert.deepEqual(runtime.sendMessage.args[0][0].urls, ['https://github.com/foo']);
+    });
+
+    it('passes an array of urls along the runtime message', () => {
+      resolvers.foo.returns([
+        'https://github.com/foo',
+        'https://github.com/bar',
+      ]);
+      $link.click();
+
+      assert.deepEqual(runtime.sendMessage.args[0][0].urls, [
+        'https://github.com/foo',
+        'https://github.com/bar',
+      ]);
+    });
+
+    describe('when url does not start with "https://github.com"', () => {
+      it('calls the ping route with the given given url', () => {
+        resolvers.foo.returns(['https://hubhub.com/foo']);
+        $link.click();
+
+        assert.deepEqual(runtime.sendMessage.args[0][0].urls, [
+          {
+            method: 'GET',
+            url: 'https://githublinker.herokuapp.com/ping?url=https://hubhub.com/foo',
+          },
+        ]);
+      });
+    });
+
+    describe('when urls contains external and github.com urls', () => {
+      it('calls the ping route only for the external urls', () => {
+        resolvers.foo.returns([
+          'https://hubhub.com/foo',
+          'https://github.com/bar',
+        ]);
+        $link.click();
+
+        assert.deepEqual(runtime.sendMessage.args[0][0].urls, [
+          {
+            method: 'GET',
+            url: 'https://githublinker.herokuapp.com/ping?url=https://hubhub.com/foo',
+          },
+          'https://github.com/bar',
+        ]);
+      });
+    });
   });
 });


### PR DESCRIPTION
While working on adding docker support #62, I've noticed that the handling of external urls is a bit nasty. In my opinion a developer shouldn't care about if a url goes to a cross origin page or not. I moved the `live-resolver-ping` parts into the `click-handler` and wrote a couple test around this. 