### PR TITLE
Publish Chrome extension only when running Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - 4
   - 6
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: node_js
 node_js:
   - 4
-  - 6
+  - 6 # if you change this, change `node: 6` in `deploy` below as well
 cache:
   directories:
     - node_modules
@@ -21,3 +21,4 @@ deploy:
     on:
       branch: master
       tags: true
+      node: 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: node_js
 node_js:
   - 4
-  - 6 # if you change this, change `node: 6` in `deploy` below as well
+  - 6
 cache:
   directories:
     - node_modules
@@ -21,4 +21,3 @@ deploy:
     on:
       branch: master
       tags: true
-      node: 6


### PR DESCRIPTION
During the v4.2.0 release, Travis tried to run the release script on
both Node 4 and Node 6, which resulted in a build [failure]. Besides,
Travis should only try to release from one build environment anyway.

[failure]: https://travis-ci.org/OctoLinker/browser-extension/jobs/148600890#L7346

https://docs.travis-ci.com/user/deployment#Examples-of-Conditional-Releases-using-on%3A