### PR TITLE
Unbreak npm

### DIFF
--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import { showTooltip } from './gh-interface.js';
+import * as resolvers from './resolver/index.js';
 import { flattenAndCompact } from './utils/array';
 
 const SORRY = 'I\'m sorry, unable to resolve this link  😱';
@@ -44,20 +45,7 @@ function getResolverUrls(dataAttr) {
   const urls = resolverStrings.map((resolverName) => {
     const resolver = resolverHandlers.get(resolverName);
     if (resolver) {
-      return [].concat(resolver(dataAttr)).map((url) => {
-        if (!url) {
-          return null;
-        }
-
-        if (url.startsWith('https://github.com')) {
-          return url;
-        }
-
-        return {
-          url: `https://githublinker.herokuapp.com/ping?url=${url}`,
-          method: 'GET',
-        };
-      });
+      return resolver(dataAttr);
     }
   });
 
@@ -90,7 +78,7 @@ function onClick(event) {
   });
 }
 
-export default function (resolvers) {
+export default function () {
   $body.undelegate(LINK_SELECTOR, 'click', onClick);
   resolverHandlers.clear();
 

--- a/lib/octo-linker.js
+++ b/lib/octo-linker.js
@@ -1,7 +1,6 @@
 import injection from 'github-injection';
 import notification from './notification';
 import BlobReader from '../packages/blob-reader';
-import * as resolvers from './resolver/index.js';
 import clickHandler from './click-handler';
 import Plugins from './plugin-manager.js';
 import debugMode from './debug-mode.js';
@@ -10,7 +9,7 @@ import loadPlugins from './load-plugins';
 
 function initialize(self) {
   debugMode(false);
-  clickHandler(resolvers);
+  clickHandler();
   notification();
 
   self._blobReader = new BlobReader();

--- a/lib/resolver/docker-image.js
+++ b/lib/resolver/docker-image.js
@@ -1,3 +1,5 @@
+import liveResolverPing from './live-resolver-ping.js';
+
 export default function ({ image }) {
   let isOffical = true;
   const imageName = image.split(':')[0];
@@ -7,6 +9,8 @@ export default function ({ image }) {
   }
 
   return [
-    `https://hub.docker.com/${isOffical ? '_' : 'r'}/${imageName}`,
+    liveResolverPing({
+      target: `https://hub.docker.com/${isOffical ? '_' : 'r'}/${imageName}`,
+    }),
   ];
 }

--- a/lib/resolver/index.js
+++ b/lib/resolver/index.js
@@ -1,4 +1,5 @@
 import liveResolverQuery from './live-resolver-query.js';
+import liveResolverPing from './live-resolver-ping.js';
 import relativeFile from './relative-file.js';
 import javascriptFile from './javascript-file.js';
 import homebrewFile from './homebrew-file.js';
@@ -10,6 +11,7 @@ import dockerImage from './docker-image.js';
 
 export {
   liveResolverQuery,
+  liveResolverPing,
   relativeFile,
   javascriptFile,
   homebrewFile,

--- a/lib/resolver/javascript-universal.js
+++ b/lib/resolver/javascript-universal.js
@@ -1,6 +1,7 @@
 import builtins from 'builtins';
 import javascriptFile from './javascript-file.js';
 import liveResolverQuery from './live-resolver-query.js';
+import liveResolverPing from './live-resolver-ping.js';
 
 function getTopModuleName(target) {
   const isScoped = target.startsWith('@');
@@ -14,7 +15,9 @@ export default function ({ path, target }) {
   const isBuildIn = builtins.indexOf(target) > -1;
 
   if (isBuildIn) {
-    return `https://nodejs.org/api/${target}.html`;
+    return liveResolverPing({
+      target: `https://nodejs.org/api/${target}.html`,
+    });
   }
 
   if (isPath) {

--- a/lib/resolver/live-resolver-ping.js
+++ b/lib/resolver/live-resolver-ping.js
@@ -1,0 +1,6 @@
+export default function ({ target }) {
+  return {
+    url: `https://githublinker.herokuapp.com/ping?url=${target}`,
+    method: 'GET',
+  };
+}

--- a/test/click-handler.test.js
+++ b/test/click-handler.test.js
@@ -1,129 +1,52 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import $ from 'jquery';
-import clickHandler from '../lib/click-handler';
+import clickHandler, { registerHandler } from '../lib/click-handler';
 
-describe('click-handler', () => {
+describe.skip('helper-click-handler', () => {
   const sandbox = sinon.sandbox.create();
-  const $link = $('<div class="octo-linker-link" data-resolver="foo" data-bar="baz"></div>');
-  let resolvers;
-  let runtime;
+  const fooHandler = sandbox.stub();
+  const barHandler = sandbox.stub();
+  const $link = $('<div class="octo-linker-link" data-type="foo" data-bar="baz"></div>');
 
   beforeEach(() => {
-    runtime = {
-      sendMessage: sandbox.stub(),
-      onMessage: {
-        addListener: sandbox.stub(),
-      },
-    };
-
-    window.chrome = {
-      runtime,
-    };
-
-    resolvers = {
-      foo: sandbox.stub(),
-      bar: sandbox.stub(),
-    };
-
-    $('body').append($link);
-    clickHandler(resolvers);
+    $('body').html($link);
+    clickHandler();
   });
 
   afterEach(() => {
     sandbox.reset();
-    $('body').off();
-    $link.remove();
+    $('body').off().empty();
   });
 
   after(() => {
     sandbox.restore();
   });
 
-  it('does not attach more than one global click handler', () => {
-    clickHandler(resolvers);
-    clickHandler(resolvers);
+  it('calls the corresponding handler', function () {
+    registerHandler('foo', fooHandler);
+    registerHandler('bar', barHandler);
     $link.click();
 
-    assert.equal(resolvers.foo.callCount, 1);
+    assert.equal(fooHandler.callCount, 1);
+    assert.equal(barHandler.callCount, 0);
   });
 
-  describe('on click', () => {
-    it('calls the corresponding resolver', () => {
-      $link.click();
+  it('calls the corresponding handler with data-attr of the target', function () {
+    registerHandler('foo', fooHandler);
+    $link.click();
 
-      assert.equal(resolvers.foo.callCount, 1);
-      assert.equal(resolvers.bar.callCount, 0);
-    });
-
-    it('calls the corresponding handler with data-attr of the target', () => {
-      $link.click();
-
-      assert.deepEqual(resolvers.foo.args[0][0], {
-        resolver: 'foo',
-        bar: 'baz',
-      });
+    assert.deepEqual(fooHandler.args[0][0], {
+      type: 'foo',
+      bar: 'baz',
     });
   });
 
-  describe('request', () => {
-    it('sends a runtime message with urls to load', () => {
-      resolvers.foo.returns('https://github.com/foo');
-      $link.click();
+  it('does not attach more than one global click handler', function () {
+    clickHandler();
+    registerHandler('foo', fooHandler);
+    $link.click();
 
-      assert.equal(runtime.sendMessage.callCount, 1);
-    });
-
-    it('passes an url string along the runtime message', () => {
-      resolvers.foo.returns('https://github.com/foo');
-      $link.click();
-
-      assert.deepEqual(runtime.sendMessage.args[0][0].urls, ['https://github.com/foo']);
-    });
-
-    it('passes an array of urls along the runtime message', () => {
-      resolvers.foo.returns([
-        'https://github.com/foo',
-        'https://github.com/bar',
-      ]);
-      $link.click();
-
-      assert.deepEqual(runtime.sendMessage.args[0][0].urls, [
-        'https://github.com/foo',
-        'https://github.com/bar',
-      ]);
-    });
-
-    describe('when url does not start with "https://github.com"', () => {
-      it('calls the ping route with the given given url', () => {
-        resolvers.foo.returns(['https://hubhub.com/foo']);
-        $link.click();
-
-        assert.deepEqual(runtime.sendMessage.args[0][0].urls, [
-          {
-            method: 'GET',
-            url: 'https://githublinker.herokuapp.com/ping?url=https://hubhub.com/foo',
-          },
-        ]);
-      });
-    });
-
-    describe('when urls contains external and github.com urls', () => {
-      it('calls the ping route only for the external urls', () => {
-        resolvers.foo.returns([
-          'https://hubhub.com/foo',
-          'https://github.com/bar',
-        ]);
-        $link.click();
-
-        assert.deepEqual(runtime.sendMessage.args[0][0].urls, [
-          {
-            method: 'GET',
-            url: 'https://githublinker.herokuapp.com/ping?url=https://hubhub.com/foo',
-          },
-          'https://github.com/bar',
-        ]);
-      });
-    });
+    assert.equal(fooHandler.callCount, 1);
   });
 });

--- a/test/resolver/docker-image.test.js
+++ b/test/resolver/docker-image.test.js
@@ -5,35 +5,60 @@ describe('docker-image', () => {
   it('resolves foo to https://hub.docker.com/_/foo', () => {
     assert.deepEqual(
       dockerImage({ image: 'foo' }),
-      ['https://hub.docker.com/_/foo']
+      [
+        {
+          url: 'https://githublinker.herokuapp.com/ping?url=https://hub.docker.com/_/foo',
+          method: 'GET',
+        },
+      ]
     );
   });
 
   it('resolves foo:1.2.3 to https://hub.docker.com/_/foo', () => {
     assert.deepEqual(
       dockerImage({ image: 'foo:1.2.3' }),
-      ['https://hub.docker.com/_/foo']
+      [
+        {
+          url: 'https://githublinker.herokuapp.com/ping?url=https://hub.docker.com/_/foo',
+          method: 'GET',
+        },
+      ]
     );
   });
 
   it('resolves foo:1.2.3-alpha to https://hub.docker.com/_/foo', () => {
     assert.deepEqual(
       dockerImage({ image: 'foo:1.2.3-alpha' }),
-      ['https://hub.docker.com/_/foo']
+      [
+        {
+          url: 'https://githublinker.herokuapp.com/ping?url=https://hub.docker.com/_/foo',
+          method: 'GET',
+        },
+      ]
     );
   });
 
   it('resolves foo/bar to https://hub.docker.com/r/foo/bar', () => {
     assert.deepEqual(
       dockerImage({ image: 'foo/bar' }),
-      ['https://hub.docker.com/r/foo/bar']
+      [
+        {
+          url: 'https://githublinker.herokuapp.com/ping?url=https://hub.docker.com/r/foo/bar',
+          method: 'GET',
+        },
+      ]
     );
   });
 
   it('resolves foo/bar:1.2.3 to https://hub.docker.com/r/foo/bar', () => {
     assert.deepEqual(
       dockerImage({ image: 'foo/bar:1.2.3' }),
-      ['https://hub.docker.com/r/foo/bar']
+      [
+        {
+          url: 'https://githublinker.herokuapp.com/ping?url=https://hub.docker.com/r/foo/bar',
+          method: 'GET',
+        },
+      ]
     );
   });
 });


### PR DESCRIPTION
This addresses https://github.com/OctoLinker/browser-extension/issues/144 by reverting the offending commit (https://github.com/OctoLinker/browser-extension/commit/c767c53fed299ded2858f8c9c792c8c5cbc5111a) and using the old way of handling cross-domain links for docker images. I'm thinking that we should merge this, figure out a way to test the correct npm behavior, then find a way to make #141 work again with the new tests.