### PR TITLE
Fix live resolver urls 

### DIFF
--- a/lib/background.js
+++ b/lib/background.js
@@ -1,11 +1,10 @@
 import $ from 'jquery';
 
 function loader(urls, cb) {
-  const req = urls.shift();
-  const url = req.url || req;
+  const { url, method = 'HEAD' } = urls.shift();
 
   $.ajax({
-    method: req.method || 'HEAD',
+    method,
     url,
   }).then(function (res) {
     cb(null, url, res);

--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -49,8 +49,14 @@ function getResolverUrls(dataAttr) {
           return null;
         }
 
-        if (url.startsWith('https://github.com')) {
+        if (typeof url === 'object') {
           return url;
+        }
+
+        if (url.startsWith('https://github.com')) {
+          return {
+            url,
+          };
         }
 
         return {

--- a/test/main-lib.js
+++ b/test/main-lib.js
@@ -1,5 +1,14 @@
 import 'babel-polyfill';
 
+window.chrome = {
+  runtime: {
+    sendMessage: () => {},
+    onMessage: {
+      addListener: () => {},
+    },
+  },
+};
+
 const context = require.context('.', true, /.+\.test\.js?$/);
 context.keys().forEach(context);
 


### PR DESCRIPTION
This is another fix for #144.

Most of the time a resolver returns either a url or an array of urls. There is only one exception, the `live-resolver-query` resolver. This on returns an object like `{url: '...', method: 'GET' }`. By default all requests are preformed as a http HEAD request. 

Also I refactored the  `background.js` file a bit. Before it was accepting a url-string and a url-object and the were mapped internally. To keep it consistent it accepts only url-object from now on. 