### PR TITLE
Add support for plugins in vimrc files

### DIFF
--- a/lib/plugins/vim/index.js
+++ b/lib/plugins/vim/index.js
@@ -1,0 +1,24 @@
+import { VIM_PLUGIN } from '../../../packages/helper-grammar-regex-collection/index.js';
+import insertLink from '../../insert-link';
+
+export default class Vim {
+
+  getPattern() {
+    return [
+      '.vimrc',
+      '.gvimrc',
+      '.vim',
+      // Sometimes there's no leading dot in .vimrc and .gvimrc, for example:
+      // https://github.com/gmarik/vimfiles/blob/1f4f26d42f54443f1158e0009746a56b9a28b053/vimrc#L136
+      'vimrc',
+      'gvimrc',
+    ];
+  }
+
+  parseBlob(blob) {
+    insertLink(blob.el, VIM_PLUGIN, {
+      resolver: 'vimPlugin',
+      shorthand: '$1',
+    });
+  }
+}

--- a/lib/resolver/index.js
+++ b/lib/resolver/index.js
@@ -7,6 +7,7 @@ import githubShorthand from './github-shorthand.js';
 import javascriptUniversal from './javascript-universal.js';
 import rubyUniversal from './ruby-universal.js';
 import dockerImage from './docker-image.js';
+import vimPlugin from './vim-plugin.js';
 
 export {
   liveResolverQuery,
@@ -18,4 +19,5 @@ export {
   githubShorthand,
   rubyUniversal,
   dockerImage,
+  vimPlugin,
 };

--- a/lib/resolver/vim-plugin.js
+++ b/lib/resolver/vim-plugin.js
@@ -7,15 +7,13 @@ export default function ({ shorthand }) {
 
   // GitHub is used when a user/repo is passed to `Plugin`.
   if (components.length === 2) {
-    return [ghShorthand(shorthand, true)];
+    return ghShorthand(shorthand, true);
   }
   // Any single word without a slash '/' is assumed to be from Vim Scripts.
   if (components.length === 1) {
-    return [ghShorthand(`vim-scripts/${shorthand}`, true)];
+    return ghShorthand(`vim-scripts/${shorthand}`, true);
   }
   // Assume it's a URL otherwise. We can't link to git/ssh, so change to https
   // and hope it works.
-  return [
-    giturl.parse(shorthand),
-  ];
+  return giturl.parse(shorthand);
 }

--- a/lib/resolver/vim-plugin.js
+++ b/lib/resolver/vim-plugin.js
@@ -1,4 +1,5 @@
 import ghShorthand from 'github-url-from-username-repo';
+import giturl from 'giturl';
 
 // Logic adapted from https://github.com/VundleVim/Vundle.vim/blob/11fdc428fe741f4f6974624ad76ab7c2b503b73e/doc/vundle.txt#L196
 export default function ({ shorthand }) {
@@ -15,7 +16,6 @@ export default function ({ shorthand }) {
   // Assume it's a URL otherwise. We can't link to git/ssh, so change to https
   // and hope it works.
   return [
-    shorthand.replace(/^git|ssh/, 'https'),
-    shorthand.replace(/^git|ssh/, 'http'),
+    giturl.parse(shorthand),
   ];
 }

--- a/lib/resolver/vim-plugin.js
+++ b/lib/resolver/vim-plugin.js
@@ -1,14 +1,16 @@
+import ghShorthand from 'github-url-from-username-repo';
+
 // Logic adapted from https://github.com/VundleVim/Vundle.vim/blob/11fdc428fe741f4f6974624ad76ab7c2b503b73e/doc/vundle.txt#L196
 export default function ({ shorthand }) {
   const components = shorthand.split('/');
 
   // GitHub is used when a user/repo is passed to `Plugin`.
   if (components.length === 2) {
-    return ['https://github.com/' + shorthand];
+    return [ghShorthand(shorthand, true)];
   }
   // Any single word without a slash '/' is assumed to be from Vim Scripts.
   if (components.length === 1) {
-    return ['https://github.com/vim-scripts/' + shorthand];
+    return [ghShorthand(`vim-scripts/${shorthand}`, true)];
   }
   // Assume it's a URL otherwise. We can't link to git/ssh, so change to https
   // and hope it works.

--- a/lib/resolver/vim-plugin.js
+++ b/lib/resolver/vim-plugin.js
@@ -1,0 +1,19 @@
+// Logic adapted from https://github.com/VundleVim/Vundle.vim/blob/11fdc428fe741f4f6974624ad76ab7c2b503b73e/doc/vundle.txt#L196
+export default function ({ shorthand }) {
+  const components = shorthand.split('/');
+
+  // GitHub is used when a user/repo is passed to `Plugin`.
+  if (components.length === 2) {
+    return ['https://github.com/' + shorthand];
+  }
+  // Any single word without a slash '/' is assumed to be from Vim Scripts.
+  if (components.length === 1) {
+    return ['https://github.com/vim-scripts/' + shorthand];
+  }
+  // Assume it's a URL otherwise. We can't link to git/ssh, so change to https
+  // and hope it works.
+  return [
+    shorthand.replace(/^git|ssh/, 'https'),
+    shorthand.replace(/^git|ssh/, 'http'),
+  ];
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "github-injection": "^0.2.0",
     "github-url-from-git": "^1.4.0",
     "github-url-from-username-repo": "^1.0.2",
+    "giturl": "^1.0.0",
     "jquery": "^2.1.4",
     "semver": "^5.1.0",
     "semver-regex": "^1.0.0"

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -10,6 +10,7 @@ const GEM = /gem (['"][^'"\s]+['"])/g;
 const HOMEBREW = /(?:depends_on|conflicts_with)(?: cask:)? (['"][^'"\s]+['"])/g;
 const TYPESCRIPT_REFERENCE = /\/{3}\s?<reference path=(['"][^'"\s]+['"])/g;
 const DOCKER_FROM = /FROM\s([^\n]*)/g;
+const VIM_PLUGIN = /(?:(?:(?:Neo)?Bundle(?:Lazy|Fetch)?)|Plug(?:in)?)\s(['"][^'"\s]+['"])/g;
 
 export {
   REQUIRE,
@@ -20,4 +21,5 @@ export {
   HOMEBREW,
   TYPESCRIPT_REFERENCE,
   DOCKER_FROM,
+  VIM_PLUGIN,
 };

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -138,6 +138,17 @@ const fixtures = {
       // 'FROM\nfoo',
     ],
   },
+  VIM_PLUGIN: {
+    valid: [
+      ["Plugin 'VundleVim/Vundle.vim'", ["'VundleVim/Vundle.vim'"]],
+      ['Plugin "VundleVim/Vundle.vim"', ['"VundleVim/Vundle.vim"']],
+      ["Plugin 'ctrlp.vim'", ["'ctrlp.vim'"]],
+      ['Plugin "ctrlp.vim"', ['"ctrlp.vim"']],
+    ],
+    invalid: [
+      "Plugin'ctrlp.vim'",
+    ],
+  },
 };
 
 describe('helper-grammar-regex-collection', () => {

--- a/test/resolver/vim-plugin.test.js
+++ b/test/resolver/vim-plugin.test.js
@@ -1,0 +1,28 @@
+import assert from 'assert';
+import vimPlugin from '../../lib/resolver/vim-plugin.js';
+
+describe('vim-plugin', () => {
+  it('resolves VundleVim/Vundle.vim to https://github.com/VundleVim/Vundle.vim', () => {
+    assert.deepEqual(
+      vimPlugin({ shorthand: 'VundleVim/Vundle.vim' }),
+      ['https://github.com/VundleVim/Vundle.vim']
+    );
+  });
+
+  it('resolves ctrlp.vim to https://github.com/vim-scripts/ctrlp.vim', () => {
+    assert.deepEqual(
+      vimPlugin({ shorthand: 'vim-scripts/ctrlp.vim' }),
+      ['https://github.com/vim-scripts/ctrlp.vim']
+    );
+  });
+
+  it('resolves a git:// URL to https/http', () => {
+    assert.deepEqual(
+      vimPlugin({ shorthand: 'git://git.wincent.com/command-t.git' }),
+      [
+        'https://git.wincent.com/command-t.git',
+        'http://git.wincent.com/command-t.git',
+      ]
+    );
+  });
+});

--- a/test/resolver/vim-plugin.test.js
+++ b/test/resolver/vim-plugin.test.js
@@ -11,7 +11,7 @@ describe('vim-plugin', () => {
 
   it('resolves ctrlp.vim to https://github.com/vim-scripts/ctrlp.vim', () => {
     assert.deepEqual(
-      vimPlugin({ shorthand: 'vim-scripts/ctrlp.vim' }),
+      vimPlugin({ shorthand: 'ctrlp.vim' }),
       ['https://github.com/vim-scripts/ctrlp.vim']
     );
   });

--- a/test/resolver/vim-plugin.test.js
+++ b/test/resolver/vim-plugin.test.js
@@ -20,8 +20,7 @@ describe('vim-plugin', () => {
     assert.deepEqual(
       vimPlugin({ shorthand: 'git://git.wincent.com/command-t.git' }),
       [
-        'https://git.wincent.com/command-t.git',
-        'http://git.wincent.com/command-t.git',
+        'http://git.wincent.com/command-t',
       ]
     );
   });

--- a/test/resolver/vim-plugin.test.js
+++ b/test/resolver/vim-plugin.test.js
@@ -5,23 +5,21 @@ describe('vim-plugin', () => {
   it('resolves VundleVim/Vundle.vim to https://github.com/VundleVim/Vundle.vim', () => {
     assert.deepEqual(
       vimPlugin({ shorthand: 'VundleVim/Vundle.vim' }),
-      ['https://github.com/VundleVim/Vundle.vim']
+      'https://github.com/VundleVim/Vundle.vim'
     );
   });
 
   it('resolves ctrlp.vim to https://github.com/vim-scripts/ctrlp.vim', () => {
     assert.deepEqual(
       vimPlugin({ shorthand: 'ctrlp.vim' }),
-      ['https://github.com/vim-scripts/ctrlp.vim']
+      'https://github.com/vim-scripts/ctrlp.vim'
     );
   });
 
   it('resolves a git:// URL to https/http', () => {
     assert.deepEqual(
       vimPlugin({ shorthand: 'git://git.wincent.com/command-t.git' }),
-      [
-        'http://git.wincent.com/command-t',
-      ]
+      'http://git.wincent.com/command-t'
     );
   });
 });


### PR DESCRIPTION
I referred to the Vundle documentation to implement the resolver:
https://github.com/VundleVim/Vundle.vim/blob/11fdc428fe741f4f6974624ad76ab7c2b503b73e/doc/vundle.txt#L196

Here's a file for testing:
https://github.com/gmarik/vimfiles/blob/1f4f26d42f54443f1158e0009746a56b9a28b053/vimrc#L136

Resolves https://github.com/OctoLinker/browser-extension/issues/31
Resolves https://github.com/OctoLinker/browser-extension/issues/41