### PR TITLE
homebrew: support `depends_on formula:` syntax

### DIFF
--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -3,11 +3,7 @@ const REQUIRE_RESOLVE = /require(?:.resolve)(?:\s|\()(['"][^'"\s]+['"])\)?/g;
 const IMPORT = /import [\r\n\s\w{},*\$]*(?: from )?(['"][^'"\s]+['"])/g;
 const EXPORT = /export [\r\n\s\w{},*\$]*(?: from )(['"][^'"\s]+['"])/g;
 const GEM = /gem (['"][^'"\s]+['"])/g;
-// TODO support `formula:` as well. See
-// https://github.com/caskroom/homebrew-cask/blob/714bd04bebd195500843dbb2cdbef21d65ff8852/doc/cask_language_reference/stanzas/depends_on.md#depends_on-formula
-// Ideally, we'd have a way of knowing which Homebrew tap is referred to, but
-// we could just use https://github.com/Homebrew/homebrew-core/
-const HOMEBREW = /(?:depends_on|conflicts_with)(?: cask:)? (['"][^'"\s]+['"])/g;
+const HOMEBREW = /(?:depends_on|conflicts_with)(?: cask:| formula:)? (['"][^'"\s]+['"])/g;
 const TYPESCRIPT_REFERENCE = /\/{3}\s?<reference path=(['"][^'"\s]+['"])/g;
 const DOCKER_FROM = /FROM\s([^\n]*)/g;
 

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -107,6 +107,10 @@ const fixtures = {
       ['depends_on cask: \'foo\'', ['\'foo\'']],
       'conflicts_with cask: "foo"',
       ['conflicts_with cask: \'foo\'', ['\'foo\'']],
+      'depends_on formula: "foo"',
+      ['depends_on formula: \'foo\'', ['\'foo\'']],
+      'conflicts_with formula: "foo"',
+      ['conflicts_with formula: \'foo\'', ['\'foo\'']],
     ],
     // These probably aren't actually invalid, but
     // https://github.com/Homebrew/homebrew-core/ has no occurences of multiple


### PR DESCRIPTION
Now that https://github.com/OctoLinker/browser-extension/pull/134 is
merged, we can just tweak the regex to support linking to formulas in
the homebrew-core tap. See here for details on the syntax:
https://github.com/caskroom/homebrew-cask/blob/714bd04bebd195500843dbb2cdbef21d65ff8852/doc/cask_language_reference/stanzas/depends_on.md#depends_on-formula

Here's a file for testing:
https://github.com/caskroom/homebrew-cask/blob/42437e5fcd93b1a3c95376794e6d5eee2b096160/test/support/Casks/with-depends-on-formula-multiple.rb#L8