### PR TITLE
Travis: only `npm run package-all` before a deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 cache:
   directories:
     - node_modules
-after_success:
+before_deploy:
   - npm run package-all
 deploy:
   - provider: releases


### PR DESCRIPTION
Since we don't usually need to have the extension packages, we can save
build time by packaging them only before a deployment, rather than on
every commit. Here's more info on when the various Travis scripts run:
https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle