### PR TITLE
Use `export { default as` syntax to dedupe resolver exports

### DIFF
--- a/lib/resolver/index.js
+++ b/lib/resolver/index.js
@@ -1,23 +1,10 @@
-import liveResolverQuery from './live-resolver-query.js';
-import relativeFile from './relative-file.js';
-import javascriptFile from './javascript-file.js';
-import homebrewFile from './homebrew-file.js';
-import gitUrl from './git-url.js';
-import githubShorthand from './github-shorthand.js';
-import javascriptUniversal from './javascript-universal.js';
-import rubyUniversal from './ruby-universal.js';
-import dockerImage from './docker-image.js';
-import vimPlugin from './vim-plugin.js';
-
-export {
-  liveResolverQuery,
-  relativeFile,
-  javascriptFile,
-  homebrewFile,
-  javascriptUniversal,
-  gitUrl,
-  githubShorthand,
-  rubyUniversal,
-  dockerImage,
-  vimPlugin,
-};
+export { default as liveResolverQuery } from './live-resolver-query.js';
+export { default as relativeFile } from './relative-file.js';
+export { default as javascriptFile } from './javascript-file.js';
+export { default as homebrewFile } from './homebrew-file.js';
+export { default as gitUrl } from './git-url.js';
+export { default as githubShorthand } from './github-shorthand.js';
+export { default as javascriptUniversal } from './javascript-universal.js';
+export { default as rubyUniversal } from './ruby-universal.js';
+export { default as dockerImage } from './docker-image.js';
+export { default as vimPlugin } from './vim-plugin.js';


### PR DESCRIPTION
This makes it so only one line is needed per resolver.

Maybe we could also do some webpack trickery to make this work like the
plugin auto-loading in ea30b42684cf60d65118562c7ffdcc267067517e, but I
haven't tried to figure that out yet.