### PR TITLE
Add Rust plugin with 'extern crate'/'use' support

### DIFF
--- a/lib/pattern-preset.js
+++ b/lib/pattern-preset.js
@@ -50,6 +50,11 @@ const presets = {
     ],
     githubClasses: ['type-viml'],
   },
+
+  'Rust': {
+    pathSubstrings: ['.rs'],
+    githubClasses: ['type-rust'],
+  },
 };
 
 export default function (presetName) {

--- a/lib/plugins/rust/index.js
+++ b/lib/plugins/rust/index.js
@@ -1,0 +1,17 @@
+import { RUST_CRATE } from '../../../packages/helper-grammar-regex-collection/index.js';
+import insertLink from '../../insert-link';
+import preset from '../../pattern-preset';
+
+export default class Rust {
+
+  getPattern() {
+    return preset('Rust');
+  }
+
+  parseBlob(blob) {
+    insertLink(blob.el, RUST_CRATE, {
+      resolver: 'rustCrate',
+      target: '$1',
+    });
+  }
+}

--- a/lib/resolver/index.js
+++ b/lib/resolver/index.js
@@ -8,3 +8,4 @@ export { default as javascriptUniversal } from './javascript-universal.js';
 export { default as rubyUniversal } from './ruby-universal.js';
 export { default as dockerImage } from './docker-image.js';
 export { default as vimPlugin } from './vim-plugin.js';
+export { default as rustCrate } from './rust-crate.js';

--- a/lib/resolver/rust-crate.js
+++ b/lib/resolver/rust-crate.js
@@ -1,0 +1,5 @@
+import liveResolverQuery from './live-resolver-query.js';
+
+export default function ({ target }) {
+  return liveResolverQuery({ type: 'crates', target });
+}

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -6,6 +6,7 @@ const HOMEBREW = /(?:depends_on|conflicts_with)(?: cask:| formula:)? (['"][^'"\s
 const TYPESCRIPT_REFERENCE = /\/{3}\s?<reference path=(['"][^'"\s]+['"])/g;
 const DOCKER_FROM = /FROM\s([^\n]*)/g;
 const VIM_PLUGIN = /(?:(?:(?:Neo)?Bundle(?:Lazy|Fetch)?)|Plug(?:in)?)\s(['"][^'"\s]+['"])/g;
+const RUST_CRATE = /(?:extern crate|use) ([^:; ]+)/g;
 
 export {
   REQUIRE,
@@ -16,4 +17,5 @@ export {
   TYPESCRIPT_REFERENCE,
   DOCKER_FROM,
   VIM_PLUGIN,
+  RUST_CRATE,
 };

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -150,6 +150,16 @@ const fixtures = {
       "Plugin'ctrlp.vim'",
     ],
   },
+  RUST_CRATE: {
+    valid: [
+      ['extern crate pcre;', ['pcre']],
+      ['extern crate std as ruststd;', ['std']],
+      ['use std::option::Option::{Some, None};', ['std']],
+    ],
+    invalid: [
+      "extern create 'pcre'",
+    ],
+  },
 };
 
 describe('helper-grammar-regex-collection', () => {

--- a/test/resolver/rust-crate.js
+++ b/test/resolver/rust-crate.js
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import rustCrate from '../../lib/resolver/rust-crate.js';
+
+describe('rust-crate', () => {
+  it('resolves hamcrest using the live-resolver', () => {
+    assert.deepEqual(
+      rustCrate({ target: 'hamcrest' }),
+      {
+        url: 'https://githublinker.herokuapp.com/q/crates/hamcrest',
+        method: 'GET',
+      }
+    );
+  });
+});


### PR DESCRIPTION
This live-resolver PR must be merged first: https://github.com/OctoLinker/live-resolver/pull/18

Resolves https://github.com/OctoLinker/browser-extension/issues/45

Test page: https://github.com/rust-lang/cargo/blob/07c1d9900de40c59b898d08d64273447560ffbe3/tests/config.rs#L1-L5