### PR TITLE
Add Python support

### DIFF
--- a/lib/pattern-preset.js
+++ b/lib/pattern-preset.js
@@ -55,6 +55,11 @@ const presets = {
     pathSubstrings: ['.rs'],
     githubClasses: ['type-rust'],
   },
+
+  'Python': {
+    pathSubstrings: ['.py'],
+    githubClasses: ['type-python'],
+  },
 };
 
 export default function (presetName) {

--- a/lib/plugins/python/index.js
+++ b/lib/plugins/python/index.js
@@ -1,0 +1,18 @@
+import { PYTHON_IMPORT } from '../../../packages/helper-grammar-regex-collection/index.js';
+import insertLink from '../../insert-link';
+import preset from '../../pattern-preset';
+
+export default class Python {
+
+  getPattern() {
+    return preset('Python');
+  }
+
+  parseBlob(blob) {
+    insertLink(blob.el, PYTHON_IMPORT, {
+      resolver: 'pythonUniversal',
+      target: '$1',
+      path: blob.path,
+    });
+  }
+}

--- a/lib/resolver/index.js
+++ b/lib/resolver/index.js
@@ -9,3 +9,4 @@ export { default as rubyUniversal } from './ruby-universal.js';
 export { default as dockerImage } from './docker-image.js';
 export { default as vimPlugin } from './vim-plugin.js';
 export { default as rustCrate } from './rust-crate.js';
+export { default as pythonUniversal } from './python-universal.js';

--- a/lib/resolver/python-universal.js
+++ b/lib/resolver/python-universal.js
@@ -1,0 +1,30 @@
+import liveResolverQuery from './live-resolver-query.js';
+import relativeFile from './relative-file.js';
+
+export default function ({ path, target }) {
+  const isLocalFile = target.startsWith('.') && target.length > 1;
+  const isInit = target === '.';
+  const apiDoc = `https://docs.python.org/3/library/${target}.html`;
+
+  if (isLocalFile) {
+    return relativeFile({
+      target: target.slice(1) + '.py',
+      path,
+    });
+  }
+
+  if (isInit) {
+    return relativeFile({
+      target: '__init__.py',
+      path,
+    });
+  }
+
+  return [
+    liveResolverQuery({
+      target: target.split('.')[0],
+      type: 'pypi',
+    }),
+    apiDoc,
+  ];
+}

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -7,6 +7,7 @@ const TYPESCRIPT_REFERENCE = /\/{3}\s?<reference path=(['"][^'"\s]+['"])/g;
 const DOCKER_FROM = /FROM\s([^\n]*)/g;
 const VIM_PLUGIN = /(?:(?:(?:Neo)?Bundle(?:Lazy|Fetch)?)|Plug(?:in)?)\s(['"][^'"\s]+['"])/g;
 const RUST_CRATE = /(?:extern crate|use) ([^:; ]+)/g;
+const PYTHON_IMPORT = /(?:(?:\n|^)\s*import|from)\s([^\s]*)/g;
 
 export {
   REQUIRE,
@@ -18,4 +19,5 @@ export {
   DOCKER_FROM,
   VIM_PLUGIN,
   RUST_CRATE,
+  PYTHON_IMPORT,
 };

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -160,6 +160,22 @@ const fixtures = {
       "extern create 'pcre'",
     ],
   },
+  PYTHON_IMPORT: {
+    valid: [
+      ['import foo', ['foo']],
+      ['\nimport foo', ['foo']],
+      ['import fo_o', ['fo_o']],
+      ['import .foo', ['.foo']],
+      ['import foo as bar', ['foo']],
+      ['from foo import bar', ['foo']],
+      ['from foo import bar, baz', ['foo']],
+      ['from foo.bar import baz', ['foo.bar']],
+    ],
+    invalid: [
+      '\simport foo',
+      '\simport\nfoo',
+    ],
+  },
 };
 
 describe('helper-grammar-regex-collection', () => {

--- a/test/resolver/python-universal.test.js
+++ b/test/resolver/python-universal.test.js
@@ -1,0 +1,42 @@
+import assert from 'assert';
+import pythonUniversal from '../../lib/resolver/python-universal.js';
+import liveResolverQuery from '../../lib/resolver/live-resolver-query.js';
+
+describe('python-universal', () => {
+  const path = '/octo/dog.py';
+
+  it('resolves local file', () => {
+    assert.deepEqual(
+      pythonUniversal({ path, target: '.foo' }),
+      'https://github.com/octo/foo.py'
+    );
+  });
+
+  it('resolves init file', () => {
+    assert.deepEqual(
+      pythonUniversal({ path, target: '.' }),
+      'https://github.com/octo/__init__.py'
+    );
+  });
+
+  it('resolves package', () => {
+    assert.deepEqual(
+      pythonUniversal({ path, target: 'foo' })[0],
+      liveResolverQuery({ type: 'pypi', target: 'foo' })
+    );
+  });
+
+  it('resolves scope package', () => {
+    assert.deepEqual(
+      pythonUniversal({ path, target: 'foo.bar' })[0],
+      liveResolverQuery({ type: 'pypi', target: 'foo' })
+    );
+  });
+
+  it('resolves buildin', () => {
+    assert.deepEqual(
+      pythonUniversal({ path, target: 'foo' })[1],
+      'https://docs.python.org/3/library/foo.html'
+    );
+  });
+});


### PR DESCRIPTION
This PR adds basic support for Python and allows clicks on `import` and `from` statements. 

Demo: https://github.com/pallets/flask/blob/master/flask/cli.py

Resolves #33 

