### PR TITLE
Store base url in a single location

### DIFF
--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -50,12 +50,15 @@ function getResolverUrls(dataAttr) {
         }
 
         if (typeof url === 'object') {
-          return url;
+          return {
+            url: url.url.replace('{BASE_URL}', 'https://github.com'),
+            method: url.method,
+          };
         }
 
-        if (url.startsWith('https://github.com')) {
+        if (url.startsWith('{BASE_URL}')) {
           return {
-            url,
+            url: url.replace('{BASE_URL}', 'https://github.com'),
           };
         }
 

--- a/lib/resolver/homebrew-file.js
+++ b/lib/resolver/homebrew-file.js
@@ -2,7 +2,7 @@ import relativeFile from './relative-file.js';
 
 export default function ({ path, target }) {
   return [
-    relativeFile({ path, target, baseUrl: 'https://github.com' }),
+    relativeFile({ path, target }),
     'https://github.com/Homebrew/homebrew-core/blob/master/Formula/' + target,
   ];
 }

--- a/lib/resolver/homebrew-file.js
+++ b/lib/resolver/homebrew-file.js
@@ -3,6 +3,6 @@ import relativeFile from './relative-file.js';
 export default function ({ path, target }) {
   return [
     relativeFile({ path, target }),
-    'https://github.com/Homebrew/homebrew-core/blob/master/Formula/' + target,
+    '{BASE_URL}/Homebrew/homebrew-core/blob/master/Formula/' + target,
   ];
 }

--- a/lib/resolver/homebrew-file.js
+++ b/lib/resolver/homebrew-file.js
@@ -2,7 +2,7 @@ import relativeFile from './relative-file.js';
 
 export default function ({ path, target }) {
   return [
-    relativeFile({ path, target }),
-    '{BASE_URL}/Homebrew/homebrew-core/blob/master/Formula/' + target,
+    relativeFile({ path, target, baseUrl: 'https://github.com' }),
+    'https://github.com/Homebrew/homebrew-core/blob/master/Formula/' + target,
   ];
 }

--- a/lib/resolver/javascript-file.js
+++ b/lib/resolver/javascript-file.js
@@ -27,6 +27,6 @@ export default function ({ path, target }) {
   list.push('');
 
   return list.map((file) => {
-    return 'https://github.com' + basePath + file;
+    return '{BASE_URL}' + basePath + file;
   });
 }

--- a/lib/resolver/relative-file.js
+++ b/lib/resolver/relative-file.js
@@ -1,5 +1,5 @@
 import { join, dirname } from 'path';
 
 export default function ({ path, target }) {
-  return 'https://github.com' + join(dirname(path), target);
+  return '{BASE_URL}' + join(dirname(path), target);
 }

--- a/lib/resolver/relative-file.js
+++ b/lib/resolver/relative-file.js
@@ -1,5 +1,5 @@
 import { join, dirname } from 'path';
 
-export default function ({ path, target, baseUrl = '{BASE_URL}' }) {
-  return baseUrl + join(dirname(path), target);
+export default function ({ path, target }) {
+  return '{BASE_URL}' + join(dirname(path), target);
 }

--- a/lib/resolver/relative-file.js
+++ b/lib/resolver/relative-file.js
@@ -1,5 +1,5 @@
 import { join, dirname } from 'path';
 
-export default function ({ path, target }) {
-  return '{BASE_URL}' + join(dirname(path), target);
+export default function ({ path, target, baseUrl = '{BASE_URL}' }) {
+  return baseUrl + join(dirname(path), target);
 }

--- a/lib/resolver/ruby-file.js
+++ b/lib/resolver/ruby-file.js
@@ -3,5 +3,5 @@ import { join } from 'path';
 export default function ({ path, target }) {
   const basePath = join(path.split('/lib/')[0], 'lib');
 
-  return 'https://github.com' + join(basePath, target + '.rb');
+  return '{BASE_URL}' + join(basePath, target + '.rb');
 }

--- a/test/click-handler.test.js
+++ b/test/click-handler.test.js
@@ -77,7 +77,7 @@ describe('click-handler', () => {
 
   describe('request', () => {
     it('sends a runtime message with urls to load', () => {
-      resolvers.foo.returns('https://github.com/foo');
+      resolvers.foo.returns('{BASE_URL}/foo');
       $link.click();
 
       assert.equal(window.chrome.runtime.sendMessage.callCount, 1);
@@ -85,7 +85,7 @@ describe('click-handler', () => {
 
     describe('when resolver returns a url', () => {
       it('passes object along the runtime message', () => {
-        resolvers.foo.returns('https://github.com/foo');
+        resolvers.foo.returns('{BASE_URL}/foo');
         $link.click();
 
         assert.deepEqual(window.chrome.runtime.sendMessage.args[0][0].urls, [
@@ -97,8 +97,8 @@ describe('click-handler', () => {
     describe('when resolver returns an array of url', () => {
       it('passes object along the runtime message', () => {
         resolvers.foo.returns([
-          'https://github.com/foo',
-          'https://github.com/bar',
+          '{BASE_URL}/foo',
+          '{BASE_URL}/bar',
         ]);
         $link.click();
 
@@ -113,7 +113,7 @@ describe('click-handler', () => {
       it('passes url object along the runtime message', () => {
         resolvers.foo.returns({
           method: 'GET',
-          url: 'https://github.com/foo',
+          url: '{BASE_URL}/foo',
         });
         $link.click();
 
@@ -138,7 +138,7 @@ describe('click-handler', () => {
       it('calls the ping route only for the external urls', () => {
         resolvers.foo.returns([
           'https://hubhub.com/foo',
-          'https://github.com/bar',
+          '{BASE_URL}/bar',
         ]);
         $link.click();
 

--- a/test/resolver/homebrew-file.test.js
+++ b/test/resolver/homebrew-file.test.js
@@ -9,7 +9,7 @@ describe('homebrew-file', () => {
         target: 'autoconf.rb',
       }),
       [
-        'https://github.com/Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/autoconf.rb',
+        '{BASE_URL}/Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/autoconf.rb',
         'https://github.com/Homebrew/homebrew-core/blob/master/Formula/autoconf.rb',
       ]
     );

--- a/test/resolver/homebrew-file.test.js
+++ b/test/resolver/homebrew-file.test.js
@@ -9,8 +9,8 @@ describe('homebrew-file', () => {
         target: 'autoconf.rb',
       }),
       [
-        'https://github.com/Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/autoconf.rb',
-        'https://github.com/Homebrew/homebrew-core/blob/master/Formula/autoconf.rb',
+        '{BASE_URL}/Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/autoconf.rb',
+        '{BASE_URL}/Homebrew/homebrew-core/blob/master/Formula/autoconf.rb',
       ]
     );
   });

--- a/test/resolver/homebrew-file.test.js
+++ b/test/resolver/homebrew-file.test.js
@@ -9,8 +9,8 @@ describe('homebrew-file', () => {
         target: 'autoconf.rb',
       }),
       [
-        '{BASE_URL}/Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/autoconf.rb',
-        '{BASE_URL}/Homebrew/homebrew-core/blob/master/Formula/autoconf.rb',
+        'https://github.com/Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/autoconf.rb',
+        'https://github.com/Homebrew/homebrew-core/blob/master/Formula/autoconf.rb',
       ]
     );
   });

--- a/test/resolver/python-universal.test.js
+++ b/test/resolver/python-universal.test.js
@@ -8,14 +8,14 @@ describe('python-universal', () => {
   it('resolves local file', () => {
     assert.deepEqual(
       pythonUniversal({ path, target: '.foo' }),
-      'https://github.com/octo/foo.py'
+      '{BASE_URL}/octo/foo.py'
     );
   });
 
   it('resolves init file', () => {
     assert.deepEqual(
       pythonUniversal({ path, target: '.' }),
-      'https://github.com/octo/__init__.py'
+      '{BASE_URL}/octo/__init__.py'
     );
   });
 

--- a/test/resolver/relative-file.test.js
+++ b/test/resolver/relative-file.test.js
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import relativeFile from '../../lib/resolver/relative-file.js';
+
+describe('relative-file', () => {
+  const path = '/octo/file.txt';
+
+  it('resolves local file', () => {
+    assert.deepEqual(
+      relativeFile({ path, target: '/foo.txt' }),
+      '{BASE_URL}/octo/foo.txt'
+    );
+  });
+
+  it('adds the given base url', () => {
+    assert.deepEqual(
+      relativeFile({ path, target: '/foo.txt', baseUrl: 'https://hub.com' }),
+      'https://hub.com/octo/foo.txt'
+    );
+  });
+});

--- a/test/resolver/relative-file.test.js
+++ b/test/resolver/relative-file.test.js
@@ -10,11 +10,4 @@ describe('relative-file', () => {
       '{BASE_URL}/octo/foo.txt'
     );
   });
-
-  it('adds the given base url', () => {
-    assert.deepEqual(
-      relativeFile({ path, target: '/foo.txt', baseUrl: 'https://hub.com' }),
-      'https://hub.com/octo/foo.txt'
-    );
-  });
 });


### PR DESCRIPTION
This PR replace the hardcoded base url with a placeholder in different places in order to store the base url in a single location. The placeholder will be replaced by the actual base url before a request made.