### PR TITLE
Escape quotes so that runs on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "version": "json -I -f assets/manifest.json -e \"this.version='`json -f package.json version`'\" && git add assets/manifest.json",
     "package-all": "npm-run-all chrome-pack firefox-pack && cp out/chrome-octolinker-$npm_package_version.zip out/opera-octolinker-$npm_package_version.zip",
     "release": "webstore upload --source out/chrome-octolinker-$npm_package_version.zip --auto-publish",
-    "chrome-manifest": "mkdir -p dist && json -e 'delete this.applications; this.permissions.shift()' < assets/manifest.json > dist/manifest.json",
+    "chrome-manifest": "mkdir -p dist && json -e \"delete this.applications; this.permissions.shift()\" < assets/manifest.json > dist/manifest.json",
     "chrome-build": "npm run chrome-manifest && webpack",
     "chrome-dist": "npm run chrome-build -- -p",
     "chrome-watch": "npm run chrome-manifest && webpack --watch",


### PR DESCRIPTION
`npm run chrome-build` will error on Windows because the `chrome-manifest` script has single quotes which is not escaped properly on Windows.