### PR TITLE
Run tests on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
 install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
+  - choco install phantomjs
   # install modules
   - npm install --no-shrinkwrap --ignore-scripts
 
@@ -17,7 +18,8 @@ test_script:
   # Make sure build works on Windows
   # - npm run package-all
   # run tests
-  # - npm test
+  - set PHANTOMJS_BIN=C:\ProgramData\chocolatey\bin\phantomjs.exe
+  - npm test
   - npm run chrome-build
   - npm run firefox-build
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   - choco install phantomjs
+  - choco install zip
   # install modules
   - npm install --no-shrinkwrap --ignore-scripts
 
@@ -16,12 +17,10 @@ test_script:
   - node --version
   - npm --version
   # Make sure build works on Windows
-  # - npm run package-all
+  - npm run package-all
   # run tests
   - set PHANTOMJS_BIN=C:\ProgramData\chocolatey\bin\phantomjs.exe
   - npm test
-  - npm run chrome-build
-  - npm run firefox-build
 
 # Don't actually build.
 build: off

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,6 +2,10 @@
 const webpackConfig = require('./webpack.config');
 webpackConfig.devtool = 'inline-source-map';
 
+if (process.env.APPVEYOR) {
+  require('phantomjs-prebuilt').path = '';
+}
+
 module.exports = function (config) {
   config.set({
     basePath: '',


### PR DESCRIPTION
This uses [Chocolatey] to install `phantomjs` and instructs `karma` to
use that version instead. `phantomjs-prebuilt` still has to be
monkey-patched to workaround the following error:

    Error during loading "C:\projects\browser-extension\node_modules/karma-phantomjs-launcher" plugin:
      Path must be a string. Received null

[Chocolatey]: https://www.appveyor.com/blog/2014/11/06/appveyor-with-a-hint-of-chocolatey/