### PR TITLE
Link `typings` and `types` fields in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ OctoLinker is the easiest and best way to navigate between files and projects on
 - `resolutions`
 - `peerDependencies`
 - `optionalDependencies`
+- `types` and `typings`
 
 ### Python
 - `import`

--- a/lib/plugins/npm-manifest/index.js
+++ b/lib/plugins/npm-manifest/index.js
@@ -39,6 +39,8 @@ export default class NpmManifest {
       '$.main': linkFile,
       '$.bin': linkFile,
       '$.browser': linkFile,
+      '$.typings': linkFile,
+      '$.types': linkFile,
     });
   }
 }


### PR DESCRIPTION
Example: https://github.com/moment/moment/blob/958846899bb4b15405c7ccf2f8cbff1712916b3a/package.json#L27

Spec: http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html