### PR TITLE
python: Try API docs before PyPI

### DIFF
--- a/lib/resolver/python-universal.js
+++ b/lib/resolver/python-universal.js
@@ -21,10 +21,10 @@ export default function ({ path, target }) {
   }
 
   return [
+    apiDoc,
     liveResolverQuery({
       target: target.split('.')[0],
       type: 'pypi',
     }),
-    apiDoc,
   ];
 }

--- a/test/resolver/python-universal.test.js
+++ b/test/resolver/python-universal.test.js
@@ -21,21 +21,21 @@ describe('python-universal', () => {
 
   it('resolves package', () => {
     assert.deepEqual(
-      pythonUniversal({ path, target: 'foo' })[0],
+      pythonUniversal({ path, target: 'foo' })[1],
       liveResolverQuery({ type: 'pypi', target: 'foo' })
     );
   });
 
   it('resolves scope package', () => {
     assert.deepEqual(
-      pythonUniversal({ path, target: 'foo.bar' })[0],
+      pythonUniversal({ path, target: 'foo.bar' })[1],
       liveResolverQuery({ type: 'pypi', target: 'foo' })
     );
   });
 
   it('resolves buildin', () => {
     assert.deepEqual(
-      pythonUniversal({ path, target: 'foo' })[1],
+      pythonUniversal({ path, target: 'foo' })[0],
       'https://docs.python.org/3/library/foo.html'
     );
   });


### PR DESCRIPTION
Some of the standard library names have been shadowed by user packages
on PyPI. For example, clicking on `argparse` in this [file] should lead
to https://docs.python.org/3/library/argparse.html, not
https://github.com/ThomasWaldmann/argparse/

This commit accomplishes that.

[file]: https://github.com/idank/bashlex/blob/b47fc8a2240af7767ebd33dca39d62a3cf05e0aa/examples/commandsubstitution-remover.py#L3