### PR TITLE
Make links more visible to the user

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,16 +1,31 @@
-.octo-linker-link {
+.octolinker-link {
   cursor: pointer;
 }
 
-.octo-linker-link:hover {
-  text-decoration: underline;
+.octolinker-link:hover {
+  text-decoration: underline !important;
 }
 
-body.octo-linker-debug .octo-linker-link {
+body.octolinker-debug .octolinker-link {
   background-color: rgba(255, 0, 255, 0.2);
   border: 1px solid rgb(255, 0, 255);
 }
 
-a.octo-linker-link {
+a.octolinker-link {
     color: inherit;
+}
+
+.octolinker-line-indicator:after {
+  content: "●";
+  position: absolute;
+  left: -4px;
+  top: -1px;
+  width: 3px;
+  transition:color .2s ease-out, color 450ms ease-in;
+  color: rgba(255, 0, 255, 0.2);
+}
+
+.octolinker-line-indicator:hover:after {
+    color: rgba(255, 0, 255, .8);
+    cursor: default;
 }

--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -82,9 +82,9 @@ function onClick(event) {
   }
 
   const dataAttr = event.currentTarget.dataset;
-  const $target = $(event.currentTarget);
+  const $tooltipTarget = $('span', event.currentTarget);
 
-  showTooltip($target, PROCESS);
+  showTooltip($tooltipTarget, PROCESS);
 
   const urls = getResolverUrls(dataAttr);
 
@@ -94,12 +94,12 @@ function onClick(event) {
 
   tryLoad(urls, (err, url, res) => {
     if (err) {
-      showTooltip($target, SORRY);
+      showTooltip($tooltipTarget, SORRY);
 
       return console.error(err); // eslint-disable-line no-console
     }
 
-    showTooltip($target, RESOLVED);
+    showTooltip($tooltipTarget, RESOLVED);
 
     const newWindow = (storage.get('newWindow') || event.metaKey || event.ctrlKey || event.which === 2);
     openUrl((res || {}).url || url, newWindow);

--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -7,7 +7,7 @@ const SORRY = 'I\'m sorry, unable to resolve this link  😱';
 const PROCESS = 'Processing  ⏳';
 const RESOLVED = 'Redirecting  🚀';
 
-const LINK_SELECTOR = '.octo-linker-link';
+const LINK_SELECTOR = '.octolinker-link';
 const $body = $('body');
 const resolverHandlers = new Map();
 

--- a/lib/insert-link.js
+++ b/lib/insert-link.js
@@ -8,9 +8,12 @@ const QUOTE_SIGNS = '"\'';
 
 function createLinkElement(text, dataAttr = {}) {
   const linkEl = document.createElement('a');
+  const spanEl = document.createElement('span');
+
+  linkEl.appendChild(spanEl);
 
   // Set link text
-  linkEl.textContent = text;
+  spanEl.textContent = text;
 
   // Add css classes
   linkEl.classList.add(CLASS_NAME);
@@ -124,8 +127,7 @@ function wrapsInnerString(text, matchValue, dataAttrObject) {
 
 function replace(portion, match, dataAttr, captureGroup) {
   const { text, node, indexInMatch } = portion;
-  const isAlreadyWrapped = node.parentNode.classList.contains(CLASS_NAME);
-
+  const isAlreadyWrapped = (node.parentNode.parentNode || node.parentNode).classList.contains(CLASS_NAME);
   if (isAlreadyWrapped) {
     return text;
   }

--- a/lib/insert-link.js
+++ b/lib/insert-link.js
@@ -1,7 +1,9 @@
 import $ from 'jquery';
 import findAndReplaceDOMText from 'findandreplacedomtext';
+import * as storage from './options/storage.js';
 
-const CLASS_NAME = 'octo-linker-link';
+const CLASS_NAME = 'octolinker-link';
+const CLASS_INDICATOR = 'octolinker-line-indicator';
 const QUOTE_SIGNS = '"\'';
 
 function createLinkElement(text, dataAttr = {}) {
@@ -12,6 +14,10 @@ function createLinkElement(text, dataAttr = {}) {
 
   // Add css classes
   linkEl.classList.add(CLASS_NAME);
+
+  if (storage.get('showLinkIndicator')) {
+    linkEl.classList.add(CLASS_INDICATOR);
+  }
 
   // Add data-* attributes
   for (const key in dataAttr) {

--- a/lib/options/options.js
+++ b/lib/options/options.js
@@ -8,6 +8,13 @@ export const options = [
   },
   {
     type: 'checkbox',
+    name: 'showLinkIndicator',
+    label: 'Show indicator if line contains OctoLinker links',
+    value: undefined,
+    defaultValue: true,
+  },
+  {
+    type: 'checkbox',
     name: 'debugMode',
     label: 'Debug mode',
     value: undefined,

--- a/test/click-handler.test.js
+++ b/test/click-handler.test.js
@@ -5,7 +5,7 @@ import clickHandler from '../lib/click-handler';
 
 describe('click-handler', () => {
   const sandbox = sinon.sandbox.create();
-  const $link = $('<div class="octo-linker-link" data-resolver="foo" data-bar="baz"></div>');
+  const $link = $('<div class="octolinker-link" data-resolver="foo" data-bar="baz"></div>');
   let resolvers;
 
   sandbox.stub(window.chrome.runtime, 'sendMessage');

--- a/test/insert-link.test.js
+++ b/test/insert-link.test.js
@@ -22,7 +22,7 @@ describe('helper-replace-keywords', () => {
       dataAttributes += ` data-${key}="${value}"`;
     }
 
-    const start = `<a class="octo-linker-link"${dataAttributes}>`;
+    const start = `<a class="octolinker-link"${dataAttributes}>`;
     const input = el.replace(/\$0/g, '');
     const output = el.replace('$0', start).replace('$0', '</a>');
 
@@ -99,14 +99,14 @@ describe('helper-replace-keywords', () => {
 
   it('wraps the element once', () => {
     const { input } = createExpectation('foo <span><i>"</i>$0foo$0<i>"</i></span>', { value: 'foo' });
-    assert.equal($('.octo-linker-link', helper(helper(input).innerHTML)).length, 1);
+    assert.equal($('.octolinker-link', helper(helper(input).innerHTML)).length, 1);
   });
 
   it('adds the given data-* attributes', () => {
     const { input } = createExpectation('foo <span><i>"</i>$0foo$0<i>"</i></span>');
     const options = { value: '$1', bar: 'baz' };
 
-    assert.deepEqual($('.octo-linker-link', helper(input, DEFAULT_REGEX, options)).data(), {
+    assert.deepEqual($('.octolinker-link', helper(input, DEFAULT_REGEX, options)).data(), {
       value: 'foo',
       bar: 'baz',
     });
@@ -116,7 +116,7 @@ describe('helper-replace-keywords', () => {
     const { input } = createExpectation('foo <span><i>"</i>$0foo$0<i>"</i></span>');
     const options = { value: 'go/$1.txt' };
 
-    assert.deepEqual($('.octo-linker-link', helper(input, DEFAULT_REGEX, options)).data(), {
+    assert.deepEqual($('.octolinker-link', helper(input, DEFAULT_REGEX, options)).data(), {
       value: 'go/foo.txt',
     });
   });

--- a/test/insert-link.test.js
+++ b/test/insert-link.test.js
@@ -22,9 +22,9 @@ describe('helper-replace-keywords', () => {
       dataAttributes += ` data-${key}="${value}"`;
     }
 
-    const start = `<a class="octolinker-link"${dataAttributes}>`;
+    const start = `<a class="octolinker-link"${dataAttributes}><span>`;
     const input = el.replace(/\$0/g, '');
-    const output = el.replace('$0', start).replace('$0', '</a>');
+    const output = el.replace('$0', start).replace('$0', '</span></a>');
 
     return {
       input,


### PR DESCRIPTION
This PR tries to solve #209 by making the octolinker links more visible to the user. I added two versions. 

The first one adds a dot next to the line number. After a short fadeIn animation the dot will stay visible. The other is a bit more pushy. A short background color flash makes the link visible to the user. The user can enable/disable both option separately. 

I'm not sure about the default behaviour. Should we enable both options and point the user to the options page? 

![](https://cloud.githubusercontent.com/assets/1393946/20771522/09106e16-b74a-11e6-9976-34fc50498b00.gif)

## Final version

![](https://cloud.githubusercontent.com/assets/1393946/20816897/0770c0b6-b825-11e6-8f64-269481d25e8f.gif)
