### PR TITLE
Store extension version in browser storage

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -1,16 +1,24 @@
 import { showNotification } from './gh-interface';
+import * as storage from './options/storage.js';
 
-let isNewVersion = false;
 const pkgVersion = require('../package.json').version.split('.').slice(0, -1).join('.');
 
-const installedVersion = window.localStorage.getItem('OctoLinkerVersion');
-window.localStorage.setItem('OctoLinkerVersion', pkgVersion);
-
-if (installedVersion && installedVersion !== pkgVersion) {
-  isNewVersion = true;
-}
-
 export default function () {
+  let isNewVersion = false;
+
+  const installedVersion = storage.get('version') || window.localStorage.getItem('OctoLinkerVersion');
+
+  // Remove this in after three releases (v4.8)
+  if (window.localStorage.getItem('OctoLinkerVersion')) {
+    window.localStorage.removeItem('OctoLinkerVersion');
+  }
+
+  storage.set('version', pkgVersion);
+
+  if (installedVersion && installedVersion !== pkgVersion) {
+    isNewVersion = true;
+  }
+
   if (isNewVersion) {
     showNotification();
   }


### PR DESCRIPTION
This fix the issue where the update notification was shown twice to the user when browsing on github.com and gist.github.com.  That happened because we stored the version in the LocalStorage. The LS is bounded to the domain and therefore the notification was appearing twice to the user. By using the browser build in storage this can be avoided. 