### PR TITLE
Fix CoffeeScript support by merging presets

### DIFF
--- a/lib/pattern-preset.js
+++ b/lib/pattern-preset.js
@@ -62,6 +62,13 @@ const presets = {
   },
 };
 
-export default function (presetName) {
-  return presets[presetName];
+export default function (presetName, siblingPresetName) {
+  if (!siblingPresetName) {
+    return presets[presetName];
+  }
+
+  return {
+    pathSubstrings: presets[presetName].pathSubstrings.concat(presets[siblingPresetName].pathSubstrings),
+    githubClasses: presets[presetName].githubClasses.concat(presets[siblingPresetName].githubClasses),
+  };
 }

--- a/lib/plugins/javascript/index.js
+++ b/lib/plugins/javascript/index.js
@@ -5,7 +5,7 @@ import preset from '../../pattern-preset';
 export default class JavaScript {
 
   getPattern() {
-    return preset('JavaScript');
+    return preset('JavaScript', 'CoffeeScript');
   }
 
   parseBlob(blob) {

--- a/test/pattern-preset.test.js
+++ b/test/pattern-preset.test.js
@@ -15,4 +15,15 @@ describe('pattern-preset', () => {
       ],
     });
   });
+
+  it('merges pattern for the given presets', () => {
+    assert.deepEqual(patternPresets('JavaScript', 'CoffeeScript'), {
+      pathSubstrings: ['.js', '.jsx', '.es6', '.coffee'],
+      githubClasses: [
+        'type-javascript',
+        'type-jsx',
+        'type-coffeescript',
+      ],
+    });
+  });
 });


### PR DESCRIPTION
Looks like CoffeeScript is broken since we added Presets. This PR will fix the issue by merging the JavaScript and CoffeeScript preset at runtime.

Alternative we could add a CoffeeScript plugin which extends JavaScript  and overwrite the preset function. What would you prefer @josephfrazier?