### PR TITLE
Do not break when passing null or undefined as data-attr

### DIFF
--- a/lib/insert-link.js
+++ b/lib/insert-link.js
@@ -33,6 +33,10 @@ function createLinkElement(text, dataAttr = {}) {
 }
 
 function getCaptureGroupIndex(captureGroup) {
+  if (!captureGroup) {
+    return undefined;
+  }
+
   const match = captureGroup.match(/\$([0-9]+)/);
   if (!match || !match[1]) {
     return undefined;

--- a/test/insert-link.test.js
+++ b/test/insert-link.test.js
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import insertLink from '../lib/insert-link.js';
 import { REQUIRE } from '../packages/helper-grammar-regex-collection';
 
-describe('helper-replace-keywords', () => {
+describe('insert-link', () => {
   const DEFAULT_REGEX = /foo ("\w+")/;
 
   function helper(html, regex = DEFAULT_REGEX, options = {}, replaceIndex = '$1') {
@@ -118,6 +118,33 @@ describe('helper-replace-keywords', () => {
 
     assert.deepEqual($('.octolinker-link', helper(input, DEFAULT_REGEX, options)).data(), {
       value: 'go/foo.txt',
+    });
+  });
+
+  it('can handle if value is undefined', () => {
+    const { input } = createExpectation('foo <span><i>"</i>$0foo$0<i>"</i></span>');
+    const options = { value: undefined };
+
+    assert.deepEqual($('.octolinker-link', helper(input, DEFAULT_REGEX, options)).data(), {
+      value: 'undefined',
+    });
+  });
+
+  it('can handle if value is null', () => {
+    const { input } = createExpectation('foo <span><i>"</i>$0foo$0<i>"</i></span>');
+    const options = { value: null };
+
+    assert.deepEqual($('.octolinker-link', helper(input, DEFAULT_REGEX, options)).data(), {
+      value: null,
+    });
+  });
+
+  it('can handle if value is empty string', () => {
+    const { input } = createExpectation('foo <span><i>"</i>$0foo$0<i>"</i></span>');
+    const options = { value: '' };
+
+    assert.deepEqual($('.octolinker-link', helper(input, DEFAULT_REGEX, options)).data(), {
+      value: '',
     });
   });
 


### PR DESCRIPTION
While adding support for issue code blocks I noticed the link creation fails if the data attribute values is null or undefined. In order to not break the app I do an early return.
