### PR TITLE
Resolve links in code blocks

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -29,3 +29,12 @@ a.octolinker-link {
     color: rgba(255, 0, 255, .8);
     cursor: default;
 }
+
+/* Fix line indicator for issue code blocks */
+.highlight {
+  position: relative;;
+}
+
+.highlight .octolinker-line-indicator:after {
+  top: inherit;
+}

--- a/lib/pattern-preset.js
+++ b/lib/pattern-preset.js
@@ -1,4 +1,4 @@
-const presets = {
+export const presets = {
 
   JavaScript: {
     pathSubstrings: [
@@ -9,6 +9,7 @@ const presets = {
     githubClasses: [
       'type-javascript',
       'type-jsx',
+      'highlight-source-js',
     ],
   },
 
@@ -16,6 +17,7 @@ const presets = {
     pathSubstrings: ['.coffee'],
     githubClasses: [
       'type-coffeescript',
+      'highlight-source-coffee',
     ],
   },
 
@@ -23,6 +25,7 @@ const presets = {
     pathSubstrings: ['.ts'],
     githubClasses: [
       'type-typescript',
+      'highlight-source-ts',
     ],
   },
 
@@ -30,12 +33,16 @@ const presets = {
     pathSubstrings: ['.rb'],
     githubClasses: [
       'type-ruby',
+      'highlight-source-ruby',
     ],
   },
 
   Docker: {
     pathSubstrings: ['Dockerfile'],
-    githubClasses: ['type-dockerfile'],
+    githubClasses: [
+      'type-dockerfile',
+      'highlight-source-dockerfile',
+    ],
   },
 
   Vim: {
@@ -48,17 +55,26 @@ const presets = {
       'vimrc',
       'gvimrc',
     ],
-    githubClasses: ['type-viml'],
+    githubClasses: [
+      'type-viml',
+      'highlight-source-viml',
+    ],
   },
 
   Rust: {
     pathSubstrings: ['.rs'],
-    githubClasses: ['type-rust'],
+    githubClasses: [
+      'type-rust',
+      'highlight-source-rust',
+    ],
   },
 
   Python: {
     pathSubstrings: ['.py'],
-    githubClasses: ['type-python'],
+    githubClasses: [
+      'type-python',
+      'highlight-source-python',
+    ],
   },
 };
 

--- a/packages/blob-reader/blob.js
+++ b/packages/blob-reader/blob.js
@@ -2,14 +2,8 @@ import { getPath, readLines } from './helper';
 
 export default class Blob {
   constructor(el) {
-    const path = getPath(el);
-
-    if (!path) {
-      return;
-    }
-
     this.el = el;
-    this.path = path;
+    this.path = getPath(el);
     this.lines = readLines(el);
   }
 

--- a/packages/blob-reader/fixtures/github.com/issue/code.html
+++ b/packages/blob-reader/fixtures/github.com/issue/code.html
@@ -1,0 +1,667 @@
+
+
+
+
+<!DOCTYPE html>
+<html lang="en" class="">
+  <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# object: http://ogp.me/ns/object# article: http://ogp.me/ns/article# profile: http://ogp.me/ns/profile#">
+    <meta charset='utf-8'>
+    
+
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/frameworks-c64b206fb6104fd10a7b4f7460f970885149c62649a7414df084683d7a0f7bf3.css" media="all" rel="stylesheet" />
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github-0b5be061c3e10e159b75a28c155e55e35b16291b462cbdb17b216bfb38f8fe19.css" media="all" rel="stylesheet" />
+    
+    
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/site-0aa4f1a4bd9907ebd09f265a95d4856cabf513dd39b891f737b1b35c39f12564.css" media="all" rel="stylesheet" />
+    
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Language" content="en">
+    <meta name="viewport" content="width=device-width">
+    
+    <title>Issue with some code blocks · Issue #2 · OctoLinker/testrepo · GitHub</title>
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
+    <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+    <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png">
+    <meta property="fb:app_id" content="1401488693436528">
+
+      <meta content="https://avatars2.githubusercontent.com/u/1393946?v=3&amp;s=400" name="twitter:image:src" /><meta content="@github" name="twitter:site" /><meta content="summary" name="twitter:card" /><meta content="Issue with some code blocks · Issue #2 · OctoLinker/testrepo" name="twitter:title" /><meta content="python
+import os
+rust
+extern crate cargotest;
+ts
+require(&#39;fs&#39;)
+js
+require(&#39;fs&#39;)
+javascript
+require(&#39;fs&#39;)
+ruby
+require(&#39;log&#39;)
+coffee
+require(&#39;fs&#39;)
+package.json
+{
+  &quot;dependencies&quot;: {
+    &quot;JSONPath&quot;: ..." name="twitter:description" />
+      <meta content="https://avatars2.githubusercontent.com/u/1393946?v=3&amp;s=400" property="og:image" /><meta content="GitHub" property="og:site_name" /><meta content="object" property="og:type" /><meta content="Issue with some code blocks · Issue #2 · OctoLinker/testrepo" property="og:title" /><meta content="https://github.com/OctoLinker/testrepo/issues/2" property="og:url" /><meta content="python
+import os
+rust
+extern crate cargotest;
+ts
+require(&#39;fs&#39;)
+js
+require(&#39;fs&#39;)
+javascript
+require(&#39;fs&#39;)
+ruby
+require(&#39;log&#39;)
+coffee
+require(&#39;fs&#39;)
+package.json
+{
+  &quot;dependencies&quot;: {
+    &quot;JSONPath&quot;: ..." property="og:description" />
+      <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
+    <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
+    <link rel="assets" href="https://assets-cdn.github.com/">
+    
+    <meta name="pjax-timeout" content="1000">
+    
+    <meta name="request-id" content="6DC04B35:6A28:48B9B6:58488FA9" data-pjax-transient>
+
+    <meta name="msapplication-TileImage" content="/windows-tile.png">
+    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="selected-link" value="repo_issues" data-pjax-transient>
+
+    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+<meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-analytics" content="UA-3769691-2">
+
+<meta content="collector.githubapp.com" name="octolytics-host" /><meta content="github" name="octolytics-app-id" /><meta content="6DC04B35:6A28:48B9B6:58488FA9" name="octolytics-dimension-request_id" />
+<meta content="/&lt;user-name&gt;/&lt;repo-name&gt;/issues/show" data-pjax-transient="true" name="analytics-location" />
+
+
+
+  <meta class="js-ga-set" name="dimension1" content="Logged Out">
+
+
+
+        <meta name="hostname" content="github.com">
+    <meta name="user-login" content="">
+
+        <meta name="expected-hostname" content="github.com">
+      <meta name="js-proxy-site-detection-payload" content="OWVmYTVjYTRiMzhhYThjMWQ2OTk3NTI5ZGIyNDM3YjAxMjAxMmIzYTA2Y2UxM2YzYjE1NTBiNjlmYmY5MDQwNXx7InJlbW90ZV9hZGRyZXNzIjoiMTA5LjE5Mi43NS41MyIsInJlcXVlc3RfaWQiOiI2REMwNEIzNTo2QTI4OjQ4QjlCNjo1ODQ4OEZBOSIsInRpbWVzdGFtcCI6MTQ4MTE1MDM3OCwiaG9zdCI6ImdpdGh1Yi5jb20ifQ==">
+
+
+      <link rel="mask-icon" href="https://assets-cdn.github.com/pinned-octocat.svg" color="#000000">
+      <link rel="icon" type="image/x-icon" href="https://assets-cdn.github.com/favicon.ico">
+
+    <meta name="html-safe-nonce" content="0d311a5642c781b7189486ef4328f37d7936fc91">
+    <meta content="0424827e2e908c98732c88f5f4850993c248de97" name="form-nonce" />
+
+    <meta http-equiv="x-pjax-version" content="6d83509c081af1e13b2a8b37771952a9">
+    
+
+      
+  <meta name="description" content="Contribute to testrepo development by creating an account on GitHub.">
+  <meta name="go-import" content="github.com/OctoLinker/testrepo git https://github.com/OctoLinker/testrepo.git">
+
+  <meta content="10505593" name="octolytics-dimension-user_id" /><meta content="OctoLinker" name="octolytics-dimension-user_login" /><meta content="45358638" name="octolytics-dimension-repository_id" /><meta content="OctoLinker/testrepo" name="octolytics-dimension-repository_nwo" /><meta content="true" name="octolytics-dimension-repository_public" /><meta content="false" name="octolytics-dimension-repository_is_fork" /><meta content="45358638" name="octolytics-dimension-repository_network_root_id" /><meta content="OctoLinker/testrepo" name="octolytics-dimension-repository_network_root_nwo" />
+  <link href="https://github.com/OctoLinker/testrepo/commits/master.atom" rel="alternate" title="Recent Commits to testrepo:master" type="application/atom+xml">
+
+
+  </head>
+
+
+  <body class="logged-out  env-production  vis-public">
+    <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
+    <a href="#start-of-content" tabindex="1" class="accessibility-aid js-skip-to-content">Skip to content</a>
+
+    
+    
+    
+
+
+
+          <header class="site-header js-details-container" role="banner">
+  <div class="container-responsive">
+    <a class="header-logo-invertocat" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
+      <svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+    </a>
+
+    <button class="btn-link float-right site-header-toggle js-details-target" type="button" aria-label="Toggle navigation">
+      <svg aria-hidden="true" class="octicon octicon-three-bars" height="24" version="1.1" viewBox="0 0 12 16" width="18"><path fill-rule="evenodd" d="M11.41 9H.59C0 9 0 8.59 0 8c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zm0-4H.59C0 5 0 4.59 0 4c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM.59 11H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1H.59C0 13 0 12.59 0 12c0-.59 0-1 .59-1z"/></svg>
+    </button>
+
+    <div class="site-header-menu">
+      <nav class="site-header-nav site-header-nav-main">
+        <a href="/personal" class="js-selected-navigation-item nav-item nav-item-personal" data-ga-click="Header, click, Nav menu - item:personal" data-selected-links="/personal /personal">
+          Personal
+</a>        <a href="/open-source" class="js-selected-navigation-item nav-item nav-item-opensource" data-ga-click="Header, click, Nav menu - item:opensource" data-selected-links="/open-source /open-source">
+          Open source
+</a>        <a href="/business" class="js-selected-navigation-item nav-item nav-item-business" data-ga-click="Header, click, Nav menu - item:business" data-selected-links="/business /business/partners /business/features /business/customers /business">
+          Business
+</a>        <a href="/explore" class="js-selected-navigation-item nav-item nav-item-explore" data-ga-click="Header, click, Nav menu - item:explore" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship /showcases /explore">
+          Explore
+</a>      </nav>
+
+      <div class="site-header-actions">
+            <a class="btn btn-primary site-header-actions-btn" href="/join?source=header-repo" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign up</a>
+          <a class="btn site-header-actions-btn mr-1" href="/login?return_to=%2FOctoLinker%2Ftestrepo%2Fissues%2F2" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign in</a>
+      </div>
+
+        <nav class="site-header-nav site-header-nav-secondary mr-md-3">
+          <a class="nav-item" href="/pricing">Pricing</a>
+          <a class="nav-item" href="/blog">Blog</a>
+          <a class="nav-item" href="https://help.github.com">Support</a>
+          <a class="nav-item header-search-link" href="https://github.com/search">Search GitHub</a>
+              <div class="header-search scoped-search site-scoped-search js-site-search" role="search">
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/search" class="js-site-search-form" data-scoped-search-url="/OctoLinker/testrepo/search" data-unscoped-search-url="/search" method="get"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div>
+    <label class="form-control header-search-wrapper js-chromeless-input-container">
+      <div class="header-search-scope">This repository</div>
+      <input type="text"
+        class="form-control header-search-input js-site-search-focus js-site-search-field is-clearable"
+        data-hotkey="s"
+        name="q"
+        placeholder="Search"
+        aria-label="Search this repository"
+        data-unscoped-placeholder="Search GitHub"
+        data-scoped-placeholder="Search"
+        autocapitalize="off">
+    </label>
+</form></div>
+
+        </nav>
+    </div>
+  </div>
+</header>
+
+
+
+    <div id="start-of-content" class="accessibility-aid"></div>
+
+      <div id="js-flash-container">
+</div>
+
+
+    <div role="main">
+        <div itemscope itemtype="http://schema.org/SoftwareSourceCode">
+    <div id="js-repo-pjax-container" data-pjax-container>
+      
+<div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav">
+  <div class="container repohead-details-container">
+
+    
+
+<ul class="pagehead-actions">
+
+  <li>
+      <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    aria-label="You must be signed in to watch a repository" rel="nofollow">
+    <svg aria-hidden="true" class="octicon octicon-eye" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
+    Watch
+  </a>
+  <a class="social-count" href="/OctoLinker/testrepo/watchers"
+     aria-label="0 users are watching this repository">
+    0
+  </a>
+
+  </li>
+
+  <li>
+      <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    aria-label="You must be signed in to star a repository" rel="nofollow">
+    <svg aria-hidden="true" class="octicon octicon-star" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"/></svg>
+    Star
+  </a>
+
+    <a class="social-count js-social-count" href="/OctoLinker/testrepo/stargazers"
+      aria-label="0 users starred this repository">
+      0
+    </a>
+
+  </li>
+
+  <li>
+      <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
+        class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+        aria-label="You must be signed in to fork a repository" rel="nofollow">
+        <svg aria-hidden="true" class="octicon octicon-repo-forked" height="16" version="1.1" viewBox="0 0 10 16" width="10"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+        Fork
+      </a>
+
+    <a href="/OctoLinker/testrepo/network" class="social-count"
+       aria-label="1 user forked this repository">
+      1
+    </a>
+  </li>
+</ul>
+
+    <h1 class="public ">
+  <svg aria-hidden="true" class="octicon octicon-repo" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+  <span class="author" itemprop="author"><a href="/OctoLinker" class="url fn" rel="author">OctoLinker</a></span><!--
+--><span class="path-divider">/</span><!--
+--><strong itemprop="name"><a href="/OctoLinker/testrepo" data-pjax="#js-repo-pjax-container">testrepo</a></strong>
+
+</h1>
+
+  </div>
+  <div class="container">
+    
+<nav class="reponav js-repo-nav js-sidenav-container-pjax"
+     itemscope
+     itemtype="http://schema.org/BreadcrumbList"
+     role="navigation"
+     data-pjax="#js-repo-pjax-container">
+
+  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+    <a href="/OctoLinker/testrepo" class="js-selected-navigation-item reponav-item" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches /OctoLinker/testrepo" itemprop="url">
+      <svg aria-hidden="true" class="octicon octicon-code" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg>
+      <span itemprop="name">Code</span>
+      <meta itemprop="position" content="1">
+</a>  </span>
+
+    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+      <a href="/OctoLinker/testrepo/issues" class="js-selected-navigation-item selected reponav-item" data-hotkey="g i" data-selected-links="repo_issues repo_labels repo_milestones /OctoLinker/testrepo/issues" itemprop="url">
+        <svg aria-hidden="true" class="octicon octicon-issue-opened" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg>
+        <span itemprop="name">Issues</span>
+        <span class="counter">1</span>
+        <meta itemprop="position" content="2">
+</a>    </span>
+
+  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+    <a href="/OctoLinker/testrepo/pulls" class="js-selected-navigation-item reponav-item" data-hotkey="g p" data-selected-links="repo_pulls /OctoLinker/testrepo/pulls" itemprop="url">
+      <svg aria-hidden="true" class="octicon octicon-git-pull-request" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+      <span itemprop="name">Pull requests</span>
+      <span class="counter">1</span>
+      <meta itemprop="position" content="3">
+</a>  </span>
+
+  <a href="/OctoLinker/testrepo/projects" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /OctoLinker/testrepo/projects">
+    <svg aria-hidden="true" class="octicon octicon-project" height="16" version="1.1" viewBox="0 0 15 16" width="15"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+    Projects
+    <span class="counter">0</span>
+</a>
+
+
+  <a href="/OctoLinker/testrepo/pulse" class="js-selected-navigation-item reponav-item" data-selected-links="pulse /OctoLinker/testrepo/pulse">
+    <svg aria-hidden="true" class="octicon octicon-pulse" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M11.5 8L8.8 5.4 6.6 8.5 5.5 1.6 2.38 8H0v2h3.6l.9-1.8.9 5.4L9 8.5l1.6 1.5H14V8z"/></svg>
+    Pulse
+</a>
+  <a href="/OctoLinker/testrepo/graphs" class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors /OctoLinker/testrepo/graphs">
+    <svg aria-hidden="true" class="octicon octicon-graph" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
+    Graphs
+</a>
+
+</nav>
+
+  </div>
+</div>
+
+<div class="container new-discussion-timeline experiment-repo-nav">
+  <div class="repository-content">
+
+    
+<style type="text/css" media="screen">
+  span.labelstyle-fc2929, .linked-labelstyle-fc2929 {  background-color: #fc2929 !important;  color: #fff !important;}.labelstyle-fc2929.selected {  background-color: #fc2929 !important;  color: #fff !important;}.label-select-menu .labelstyle-fc2929.selected {  background:rgba(252, 41, 41, 0.12) !important;  color: #991818 !important;}
+
+span.labelstyle-cccccc, .linked-labelstyle-cccccc {  background-color: #cccccc !important;  color: #333333 !important;}.labelstyle-cccccc.selected {  background-color: #cccccc !important;  color: #333333 !important;}.label-select-menu .labelstyle-cccccc.selected {  background:rgba(204, 204, 204, 0.12) !important;  color: #999999 !important;}
+
+span.labelstyle-84b6eb, .linked-labelstyle-84b6eb {  background-color: #84b6eb !important;  color: #1c2733 !important;}.labelstyle-84b6eb.selected {  background-color: #84b6eb !important;  color: #1c2733 !important;}.label-select-menu .labelstyle-84b6eb.selected {  background:rgba(132, 182, 235, 0.12) !important;  color: #557699 !important;}
+
+span.labelstyle-159818, .linked-labelstyle-159818 {  background-color: #159818 !important;  color: #fff !important;}.labelstyle-159818.selected {  background-color: #159818 !important;  color: #fff !important;}.label-select-menu .labelstyle-159818.selected {  background:rgba(21, 152, 24, 0.12) !important;  color: #159918 !important;}
+
+span.labelstyle-e6e6e6, .linked-labelstyle-e6e6e6 {  background-color: #e6e6e6 !important;  color: #333333 !important;}.labelstyle-e6e6e6.selected {  background-color: #e6e6e6 !important;  color: #333333 !important;}.label-select-menu .labelstyle-e6e6e6.selected {  background:rgba(230, 230, 230, 0.12) !important;  color: #999999 !important;}
+
+span.labelstyle-cc317c, .linked-labelstyle-cc317c {  background-color: #cc317c !important;  color: #fff !important;}.labelstyle-cc317c.selected {  background-color: #cc317c !important;  color: #fff !important;}.label-select-menu .labelstyle-cc317c.selected {  background:rgba(204, 49, 124, 0.12) !important;  color: #99245c !important;}
+
+span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !important;  color: #333333 !important;}.labelstyle-ffffff.selected {  background-color: #ffffff !important;  color: #333333 !important;}.label-select-menu .labelstyle-ffffff.selected {  background:rgba(255, 255, 255, 0.12) !important;  color: #999999 !important;}
+</style>
+
+<div class="issues-listing" data-pjax>
+    <div id="show_issue" class="js-issues-results">
+
+    
+  <div
+    id="partial-discussion-header"
+    class="gh-header js-details-container js-socket-channel js-updatable-content issue"
+    data-channel="tenant:1:issue:185246647"
+    data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Ftitle">
+
+  <div class="gh-header-show ">
+      <div class="gh-header-actions">
+          <a href="/OctoLinker/testrepo/issues/new" class="btn btn-sm btn-primary float-right" data-hotkey="c">
+            New issue
+          </a>
+      </div>
+
+    <h1 class="gh-header-title">
+      <span class="js-issue-title">
+        Issue with some code blocks
+      </span>
+      <span class="gh-header-number">#2</span>
+    </h1>
+  </div>
+
+
+  <div class="TableObject gh-header-meta">
+    <div class="TableObject-item">
+        <div class="state state-open">
+          <svg aria-hidden="true" class="octicon octicon-issue-opened" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg>
+          Open
+        </div>
+    </div>
+    <div class="TableObject-item TableObject-item--primary">
+        <a href="/stefanbuck" class="author">stefanbuck</a>  opened this <span class="noun">Issue</span> <relative-time datetime="2016-10-25T22:05:33Z">Oct 25, 2016</relative-time>
+        &middot; 0 comments
+    </div>
+  </div>
+</div>
+
+
+    <div id="discussion_bucket" class="clearfix">
+      <div class="discussion-sidebar ">
+        <div id="partial-discussion-sidebar"
+  class="js-socket-channel js-updatable-content"
+  data-channel="tenant:1:issue:185246647"
+  data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Fsidebar">
+
+    <div class="discussion-sidebar-item sidebar-assignee js-discussion-sidebar-item">
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Fassignees" class="js-issue-sidebar-form" data-form-nonce="0424827e2e908c98732c88f5f4850993c248de97" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="/OT0pkn9KpqteJDcpwqnmB4NejjVas35fC0FCfQI7uzpAvZpdruPpeaVvQTlbBgSDMf4/jv4mcYVxuGy9cZbig==" /></div>
+    
+  <h3 class="discussion-sidebar-heading">
+    Assignees
+  </h3>
+
+
+    <span class="css-truncate">
+    No one assigned
+</span>
+
+</form></div>
+
+    <div class="discussion-sidebar-item sidebar-labels js-discussion-sidebar-item">
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Flabels" class="js-issue-sidebar-form" data-form-nonce="0424827e2e908c98732c88f5f4850993c248de97" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="DqhNeX9XvGh9h/FRbNuC8tGQOiO3f9urdR0j9r76NH4bTk+2QBEZVzZq3IkuvT14w1q45Vntj5Qc9sdNvzSBGA==" /></div>
+      
+  <h3 class="discussion-sidebar-heading">
+    Labels
+  </h3>
+
+
+    <div class="labels css-truncate">
+    None yet
+</div>
+
+</form></div>
+
+    <div class="discussion-sidebar-item js-discussion-sidebar-item">
+  
+  <h3 class="discussion-sidebar-heading">
+    Projects
+  </h3>
+
+
+  <span class="css-truncate">
+    None yet
+</span>
+
+</div>
+
+    
+    <div id="partial-users-participants" class="discussion-sidebar-item">
+  <div class="participation">
+
+    <h3 class="discussion-sidebar-heading">
+      1 participant
+    </h3>
+    <div class="participation-avatars">
+        <a class="participant-avatar tooltipped tooltipped-n" aria-label="stefanbuck" href="/stefanbuck"><img alt="@stefanbuck" class="avatar" height="26" src="https://avatars0.githubusercontent.com/u/1393946?v=3&amp;s=52" width="26" /> </a>
+    </div>
+  </div>
+</div>
+
+
+    
+    <div class="discussion-sidebar-item sidebar-milestone js-discussion-sidebar-item">
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2/set_milestone?partial=issues%2Fsidebar%2Fshow%2Fmilestone" class="js-issue-sidebar-form" data-form-nonce="0424827e2e908c98732c88f5f4850993c248de97" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="wVzJOoI68uZ2UL6F+3koLM4Pg8LPRK9VQukdzdAwkVLUusv1vXxX2T29k125H5em3MUBBCHW+2orAvl20f4kNA==" /></div>
+    
+  <h3 class="discussion-sidebar-heading">
+    Milestone
+  </h3>
+
+
+      No milestone
+
+</form></div>
+
+
+</div>
+
+      </div>
+
+      <div class="discussion-timeline js-quote-selection-container ">
+
+        <div class="js-discussion js-socket-channel" data-channel="tenant:1:marked-as-read:issue:185246647">
+          
+
+  <div class="timeline-comment-wrapper js-comment-container">
+    <a href="/stefanbuck"><img alt="@stefanbuck" class="timeline-comment-avatar" height="44" src="https://avatars3.githubusercontent.com/u/1393946?v=3&amp;s=88" width="44" /></a>
+    
+
+<div id="issue-185246647"
+     class="comment previewable-edit timeline-comment js-comment js-task-list-container
+                    
+                      "
+     data-body-version="84502f1330f9e1fdd3d42403b72c70ed">
+
+  
+<div class="timeline-comment-header ">
+
+  <div class="timeline-comment-actions">
+
+
+  </div>
+
+    <span class="timeline-comment-label
+      text-bold
+        tooltipped tooltipped-multiline tooltipped-s" aria-label="This user is a member of the OctoLinker organization.
+      ">
+      Member
+    </span>
+
+
+  <div class="timeline-comment-header-text">
+
+    <strong>
+      <a href="/stefanbuck" class="author">stefanbuck</a> 
+    </strong>
+
+    commented
+
+      <a href="#issue-185246647" class="timestamp" aria-label="Link to this comment"><relative-time datetime="2016-10-25T22:05:33Z">Oct 25, 2016</relative-time></a>
+
+      &#8226;
+      <span class="timestamp timestamp-edited tooltipped tooltipped-n"
+            aria-label="stefanbuck edited this issue less than a minute ago">
+        edited
+      </span>
+  </div>
+</div>
+
+
+  <div class="edit-comment-hide">
+    <table class="d-block">
+      <tbody class="d-block">
+        <tr class="d-block">
+          <td class="d-block comment-body markdown-body markdown-format js-comment-body">
+              <p>python</p>
+<div class="highlight highlight-source-python"><pre><span class="pl-k">import</span> os</pre></div>
+<p>rust</p>
+<div class="highlight highlight-source-rust"><pre><span class="pl-k">extern</span> <span class="pl-k">crate</span> cargotest<span class="pl-k">;</span></pre></div>
+<p>ts</p>
+<div class="highlight highlight-source-ts"><pre><span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">'</span>fs<span class="pl-pds">'</span></span>)</pre></div>
+<p>js</p>
+<div class="highlight highlight-source-js"><pre><span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">'</span>fs<span class="pl-pds">'</span></span>)</pre></div>
+<p>javascript</p>
+<div class="highlight highlight-source-js"><pre><span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">'</span>fs<span class="pl-pds">'</span></span>)</pre></div>
+<p>ruby</p>
+<div class="highlight highlight-source-ruby"><pre><span class="pl-k">require</span>(<span class="pl-s"><span class="pl-pds">'</span>log<span class="pl-pds">'</span></span>)</pre></div>
+<p>coffee</p>
+<div class="highlight highlight-source-coffee"><pre><span class="pl-c1">require</span>(<span class="pl-s"><span class="pl-pds">'</span>fs<span class="pl-pds">'</span></span>)</pre></div>
+<p>package.json</p>
+<div class="highlight highlight-source-json"><pre>{
+  <span class="pl-s"><span class="pl-pds">"</span>dependencies<span class="pl-pds">"</span></span>: {
+    <span class="pl-s"><span class="pl-pds">"</span>JSONPath<span class="pl-pds">"</span></span>: <span class="pl-s"><span class="pl-pds">"</span>^0.11.2<span class="pl-pds">"</span></span>,
+    <span class="pl-s"><span class="pl-pds">"</span>babel-polyfill<span class="pl-pds">"</span></span>: <span class="pl-s"><span class="pl-pds">"</span>^6.3.14<span class="pl-pds">"</span></span>
+  }
+}</pre></div>
+<p>Project.json</p>
+<div class="highlight highlight-source-json"><pre>{
+ <span class="pl-s"><span class="pl-pds">"</span>dependencies<span class="pl-pds">"</span></span>: {
+    <span class="pl-s"><span class="pl-pds">"</span>Microsoft.AspNetCore.Diagnostics<span class="pl-pds">"</span></span>: <span class="pl-s"><span class="pl-pds">"</span>1.0.0<span class="pl-pds">"</span></span>
+  }
+}</pre></div>
+<p>dockerfile</p>
+<div class="highlight highlight-source-dockerfile"><pre><span class="pl-k">FROM</span> node:latest</pre></div>
+<div class="highlight highlight-source-viml"><pre>Bundle <span class="pl-s"><span class="pl-pds">"</span>YankRing.vim<span class="pl-pds">"</span></span>
+Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/vim-quickrun.git<span class="pl-pds">"</span></span>
+Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/vim-poslist.git<span class="pl-pds">"</span></span></pre></div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+      
+
+<div class="comment-reactions  js-reactions-container "
+
+    >
+</div>
+
+  </div>
+
+</div>
+
+  </div>
+
+
+
+
+
+<!-- Rendered timeline since 2016-12-07 14:39:11 -->
+<div id="partial-timeline-marker"
+      class="js-timeline-marker js-socket-channel js-updatable-content"
+      data-channel="tenant:1:issue:185246647"
+      data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Ftimeline_marker&amp;since=1481150351"
+      data-last-modified="Wed, 07 Dec 2016 22:39:11 GMT">
+
+    <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/notifications/mark?ids=176302197" class="d-none js-timeline-marker-form" data-form-nonce="0424827e2e908c98732c88f5f4850993c248de97" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="PsOT1RXgLHk+/4hO/26i11HAyc+GDXvmu9m+VTQtDTMrJZEaKqaJRnUSpZa9CB1dQwpLCWifL9nSMlruNeO4VQ==" /></div>
+</form></div>
+
+
+        </div>
+
+          <div class="discussion-timeline-actions">
+                <div class="signed-out-comment">
+    <a href="/join?source=comment-repo" class="btn btn-primary" rel="nofollow">Sign up for free</a>
+    <strong>to join this conversation on GitHub</strong>.
+    Already have an account?
+    <a href="/login?return_to=https%3A%2F%2Fgithub.com%2FOctoLinker%2Ftestrepo%2Fissues%2F2" rel="nofollow">Sign in to comment</a>
+</div>
+
+
+          </div>
+      </div>
+
+    </div>
+    <div class="clear"></div>
+  </div>
+
+</div>
+
+
+  </div>
+  <div class="modal-backdrop js-touch-events"></div>
+</div>
+
+
+    </div>
+  </div>
+
+    </div>
+
+        <div class="container site-footer-container">
+  <div class="site-footer" role="contentinfo">
+    <ul class="site-footer-links float-right">
+        <li><a href="https://github.com/contact" data-ga-click="Footer, go to contact, text:contact">Contact GitHub</a></li>
+      <li><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
+      <li><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
+      <li><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
+        <li><a href="https://github.com/blog" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
+        <li><a href="https://github.com/about" data-ga-click="Footer, go to about, text:about">About</a></li>
+
+    </ul>
+
+    <a href="https://github.com" aria-label="Homepage" class="site-footer-mark" title="GitHub">
+      <svg aria-hidden="true" class="octicon octicon-mark-github" height="24" version="1.1" viewBox="0 0 16 16" width="24"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+</a>
+    <ul class="site-footer-links">
+      <li>&copy; 2016 <span title="0.13557s from github-fe124-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
+        <li><a href="https://github.com/site/terms" data-ga-click="Footer, go to terms, text:terms">Terms</a></li>
+        <li><a href="https://github.com/site/privacy" data-ga-click="Footer, go to privacy, text:privacy">Privacy</a></li>
+        <li><a href="https://github.com/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
+        <li><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
+        <li><a href="https://help.github.com" data-ga-click="Footer, go to help, text:help">Help</a></li>
+    </ul>
+  </div>
+</div>
+
+
+
+    
+
+    <div id="ajax-error-message" class="ajax-error-message flash flash-error">
+      <svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M8.865 1.52c-.18-.31-.51-.5-.87-.5s-.69.19-.87.5L.275 13.5c-.18.31-.18.69 0 1 .19.31.52.5.87.5h13.7c.36 0 .69-.19.86-.5.17-.31.18-.69.01-1L8.865 1.52zM8.995 13h-2v-2h2v2zm0-3h-2V6h2v4z"/></svg>
+      <button type="button" class="flash-close js-flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
+        <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"/></svg>
+      </button>
+      You can't perform that action at this time.
+    </div>
+
+
+      <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/compat-30ce4c86c27f88c3d1b4eb03efda59b45d8d7c871880dee0b8f73d5ef1b25fdf.js"></script>
+      <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-786af1c64a30401bf0a16eafed51415b9bcb03f72ff3183a1fa6007d7cb0f979.js"></script>
+      <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github-2031f7ecd9e1576fa074cb5657a96fa3e86493c89ba73a1bf372e6eba8eb44ee.js"></script>
+      
+      
+      
+      
+    <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner d-none">
+      <svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M8.865 1.52c-.18-.31-.51-.5-.87-.5s-.69.19-.87.5L.275 13.5c-.18.31-.18.69 0 1 .19.31.52.5.87.5h13.7c.36 0 .69-.19.86-.5.17-.31.18-.69.01-1L8.865 1.52zM8.995 13h-2v-2h2v2zm0-3h-2V6h2v4z"/></svg>
+      <span class="signed-in-tab-flash">You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
+      <span class="signed-out-tab-flash">You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
+    </div>
+    <div class="facebox" id="facebox" style="display:none;">
+  <div class="facebox-popup">
+    <div class="facebox-content" role="dialog" aria-labelledby="facebox-header" aria-describedby="facebox-description">
+    </div>
+    <button type="button" class="facebox-close js-facebox-close" aria-label="Close modal">
+      <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"/></svg>
+    </button>
+  </div>
+</div>
+
+  </body>
+</html>
+

--- a/packages/blob-reader/helper.js
+++ b/packages/blob-reader/helper.js
@@ -5,7 +5,13 @@ function getBlobCodeInner(el) {
 }
 
 function getBlobWrapper() {
-  return [].slice.call(document.getElementsByClassName('blob-wrapper'));
+  let ret = [].slice.call(document.getElementsByClassName('blob-wrapper'));
+
+  if (!ret.length) {
+    ret = [].slice.call(document.getElementsByClassName('highlight'));
+  }
+
+  return ret;
 }
 
 function mergeRepoAndFilePath(repoPath, filePath) {
@@ -121,6 +127,17 @@ function readLine(el) {
 }
 
 function readLines(el) {
+  if (el.classList.contains('highlight')) {
+    const issueCode = el.getElementsByTagName('pre');
+
+    if (issueCode.length) {
+      return issueCode[0].innerText.split(/\n/).map((line, index) => ({
+        value: line,
+        lineNumber: index + 1,
+      }));
+    }
+  }
+
   return getBlobCodeInner(el).map(readLine).filter(line => !!line);
 }
 

--- a/packages/blob-reader/scripts/update-fixtures.sh
+++ b/packages/blob-reader/scripts/update-fixtures.sh
@@ -7,3 +7,4 @@ curl https://github.com/OctoLinker/testrepo/commit/b0775a93ea27ee381858ddd9fa2bb
 curl https://gist.github.com/josephfrazier/113827963013e98c6196db51cd889c39 > packages/blob-reader/fixtures/github.com/gist/113827963013e98c6196db51cd889c39.html
 curl https://github.com/OctoLinker/testrepo/pull/1 > packages/blob-reader/fixtures/github.com/pull/comments.html
 curl https://github.com/OctoLinker/testrepo/pull/1/files > packages/blob-reader/fixtures/github.com/pull/diff.html
+curl https://github.com/OctoLinker/testrepo/issues/2 > packages/blob-reader/fixtures/github.com/issue/code.html

--- a/packages/blob-reader/test.js
+++ b/packages/blob-reader/test.js
@@ -210,4 +210,33 @@ describe('blob-reader', () => {
       assert.equal(result.path, 'package.json');
     });
   });
+
+  describe('issue', () => {
+    let result;
+
+    beforeEach(() => {
+      fixture.load('/packages/blob-reader/fixtures/github.com/issue/code.html');
+      const reader = new BlobReader();
+      result = reader.read()._blobs[0];
+    });
+
+    it('contains blob root element', () => {
+      assert(result.el !== undefined);
+    });
+
+    it('contains lines', () => {
+      assert(Array.isArray(result.lines));
+      assert.equal(result.lines.length, 1);
+      assert.deepEqual(result.lines, [
+        {
+          value: 'import os',
+          lineNumber: 1,
+        },
+      ]);
+    });
+
+    it('does not contain path', () => {
+      assert.equal(result.path, undefined);
+    });
+  });
 });

--- a/test/pattern-preset.test.js
+++ b/test/pattern-preset.test.js
@@ -1,7 +1,31 @@
 import assert from 'assert';
-import patternPresets from '../lib/pattern-preset.js';
+import patternPresets, { presets } from '../lib/pattern-preset.js';
 
 describe('pattern-preset', () => {
+  describe('githubClasses', () => {
+    describe('highlight', () => {
+      afterEach(() => {
+        fixture.cleanup();
+      });
+
+      beforeEach(() => {
+        fixture.load('/packages/blob-reader/fixtures/github.com/issue/code.html');
+      });
+
+      for (const [lang, value] of Object.entries(presets)) {
+        value.githubClasses.forEach((className) => {
+          if (!className.includes('highlight')) {
+            return;
+          }
+
+          it(`Found ${className} for ${lang}`, () => {
+            assert.equal(!!document.querySelector(`.${className}`), true);
+          });
+        });
+      }
+    });
+  });
+
   it('returns patterns for the given preset', () => {
     assert.deepEqual(patternPresets('JavaScript'), {
       pathSubstrings: [
@@ -12,6 +36,7 @@ describe('pattern-preset', () => {
       githubClasses: [
         'type-javascript',
         'type-jsx',
+        'highlight-source-js',
       ],
     });
   });
@@ -22,7 +47,9 @@ describe('pattern-preset', () => {
       githubClasses: [
         'type-javascript',
         'type-jsx',
+        'highlight-source-js',
         'type-coffeescript',
+        'highlight-source-coffee',
       ],
     });
   });


### PR DESCRIPTION
Finally I managed to resolve links within discussion and other documents like markdown files. By the nature of those files it will not work for relative paths. Also it doesn't work for JSON blocks. Anyway, it's quite handy and provides more value to the user.

## Works in discussions
![screen shot 2016-12-08 at 00 47 58](https://cloud.githubusercontent.com/assets/1393946/20991709/23d6b2e6-bce0-11e6-8d24-730d4e063227.png)

## or in README files
![screen shot 2016-12-08 at 00 46 58](https://cloud.githubusercontent.com/assets/1393946/20991711/25809878-bce0-11e6-91a9-c7870bc3a9e1.png)


### Dependencies

- [x]  #222 needs to be merged before this. FYI @josephfrazier 