### PR TITLE
Track usage of extension via GA

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -38,6 +38,7 @@
       "all_frames": false
     }
   ],
+  "content_security_policy": "script-src 'self' https://www.google-analytics.com; object-src 'self'",
   "permissions": [
     "storage",
     "https://github.com/",

--- a/lib/background.js
+++ b/lib/background.js
@@ -1,4 +1,29 @@
 import $ from 'jquery';
+import * as storage from './options/storage.js';
+
+function initGoogleAnalytics() {
+  if (!storage.get('doTrack')) {
+    return;
+  }
+
+  /* eslint-disable */
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  /* eslint-enable */
+
+  window.ga('create', 'UA-88792224-1', 'auto');
+  window.ga('set', 'anonymizeIp', true);
+  window.ga('set', 'checkProtocolTask', () => {}); // Removes failing protocol check. @see: http://stackoverflow.com/a/22152353/1958200
+}
+
+function trackEvent({ category, action, label, value }) {
+  if (!window.ga) {
+    return;
+  }
+  window.ga('send', 'event', category, action, label, value);
+}
 
 function loader(urls, cb) {
   const { url, method = 'HEAD' } = urls.shift();
@@ -7,9 +32,19 @@ function loader(urls, cb) {
     method,
     url,
   }).then((res) => {
+    trackEvent({
+      category: 'fetch',
+      action: 'success',
+    });
+
     cb(null, url, res);
   }).fail(() => {
     if (urls.length === 0) {
+      trackEvent({
+        category: 'fetch',
+        action: 'error',
+      });
+
       return cb(new Error('Could not load any url'));
     }
 
@@ -17,12 +52,26 @@ function loader(urls, cb) {
   });
 }
 
-chrome.runtime.onMessage.addListener(({ urls }, sender) => {
-  loader(urls, (err, url, res) => {
-    chrome.tabs.sendMessage(sender.tab.id, {
-      err,
-      url,
-      res,
+chrome.runtime.onMessage.addListener(({ type, payload }, sender) => {
+  if (type === 'track') {
+    trackEvent(payload);
+    return;
+  }
+
+  if (type === 'fetch') {
+    loader(payload, (err, url, res) => {
+      chrome.tabs.sendMessage(sender.tab.id, {
+        err,
+        url,
+        res,
+      });
     });
-  });
+    return;
+  }
+
+  throw new Error(`Can not handle type "${type}"`);
+});
+
+storage.load(() => {
+  initGoogleAnalytics();
 });

--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -35,7 +35,8 @@ function tryLoad(urls, cb) {
   }
 
   chrome.runtime.sendMessage({
-    urls,
+    type: 'fetch',
+    payload: urls,
   });
 }
 
@@ -45,6 +46,15 @@ function getResolverUrls(dataAttr) {
   const urls = resolverStrings.map((resolverName) => {
     const resolver = resolverHandlers.get(resolverName);
     if (resolver) {
+      chrome.runtime.sendMessage({
+        type: 'track',
+        payload: {
+          category: 'resolver',
+          action: 'invoke',
+          label: resolverName,
+        },
+      });
+
       return [].concat(resolver(dataAttr)).map((url) => {
         if (!url) {
           return null;

--- a/lib/options/options.js
+++ b/lib/options/options.js
@@ -15,6 +15,13 @@ export const options = [
   },
   {
     type: 'checkbox',
+    name: 'doTrack',
+    label: 'Send anonymous usage reports to Google Analytics',
+    value: undefined,
+    defaultValue: true,
+  },
+  {
+    type: 'checkbox',
     name: 'debugMode',
     label: 'Debug mode',
     value: undefined,

--- a/lib/options/storage.js
+++ b/lib/options/storage.js
@@ -11,6 +11,17 @@ export const load = (cb) => {
   (chrome.storage.sync || chrome.storage.local).get(null, (data) => {
     Object.assign(store, defaults, data);
 
+    for (const [key, value] of Object.entries(store)) {
+      chrome.runtime.sendMessage({
+        type: 'track',
+        payload: {
+          category: 'options',
+          action: key,
+          label: value.toString(),
+        },
+      });
+    }
+
     cb();
   });
 };

--- a/test/click-handler.test.js
+++ b/test/click-handler.test.js
@@ -76,11 +76,11 @@ describe('click-handler', () => {
   });
 
   describe('request', () => {
-    it('sends a runtime message with urls to load', () => {
+    it('sends a runtime message from type fetch', () => {
       resolvers.foo.returns('{BASE_URL}/foo');
       $link.click();
 
-      assert.equal(window.chrome.runtime.sendMessage.callCount, 1);
+      assert.equal(window.chrome.runtime.sendMessage.args[1][0].type, 'fetch');
     });
 
     describe('when resolver returns a url', () => {
@@ -88,7 +88,7 @@ describe('click-handler', () => {
         resolvers.foo.returns('{BASE_URL}/foo');
         $link.click();
 
-        assert.deepEqual(window.chrome.runtime.sendMessage.args[0][0].urls, [
+        assert.deepEqual(window.chrome.runtime.sendMessage.args[1][0].payload, [
           { url: 'https://github.com/foo' },
         ]);
       });
@@ -102,7 +102,7 @@ describe('click-handler', () => {
         ]);
         $link.click();
 
-        assert.deepEqual(window.chrome.runtime.sendMessage.args[0][0].urls, [
+        assert.deepEqual(window.chrome.runtime.sendMessage.args[1][0].payload, [
           { url: 'https://github.com/foo' },
           { url: 'https://github.com/bar' },
         ]);
@@ -117,7 +117,7 @@ describe('click-handler', () => {
         });
         $link.click();
 
-        assert.deepEqual(window.chrome.runtime.sendMessage.args[0][0].urls, [
+        assert.deepEqual(window.chrome.runtime.sendMessage.args[1][0].payload, [
           { method: 'GET', url: 'https://github.com/foo' },
         ]);
       });
@@ -128,7 +128,7 @@ describe('click-handler', () => {
         resolvers.foo.returns(['https://hubhub.com/foo']);
         $link.click();
 
-        assert.deepEqual(window.chrome.runtime.sendMessage.args[0][0].urls, [
+        assert.deepEqual(window.chrome.runtime.sendMessage.args[1][0].payload, [
           { method: 'GET', url: 'https://githublinker.herokuapp.com/ping?url=https://hubhub.com/foo' },
         ]);
       });
@@ -142,10 +142,28 @@ describe('click-handler', () => {
         ]);
         $link.click();
 
-        assert.deepEqual(window.chrome.runtime.sendMessage.args[0][0].urls, [
+        assert.deepEqual(window.chrome.runtime.sendMessage.args[1][0].payload, [
           { method: 'GET', url: 'https://githublinker.herokuapp.com/ping?url=https://hubhub.com/foo' },
           { url: 'https://github.com/bar' },
         ]);
+      });
+    });
+
+    it('sends a runtime message from type track', () => {
+      resolvers.foo.returns('{BASE_URL}/foo');
+      $link.click();
+
+      assert.equal(window.chrome.runtime.sendMessage.args[0][0].type, 'track');
+    });
+
+    it('tracks the resolver identity', () => {
+      resolvers.foo.returns('{BASE_URL}/foo');
+      $link.click();
+
+      assert.deepEqual(window.chrome.runtime.sendMessage.args[0][0].payload, {
+        category: 'resolver',
+        action: 'invoke',
+        label: 'foo',
       });
     });
   });


### PR DESCRIPTION
Collect some basic information to get some insights about how the extension is used. 

## What we collect

**We do not** collect any personal identification information about Users whenever they interact with the OctoLinker.

**We do** collect non-personal identification information about Users whenever they interact with the OctoLinker. Non-personal identification information include the OctoLinker preferences from the option page, the link resolver name which is used to redirect you and if the redirect was succesful or not.

Please note that we use the Analytics extension `ga('set', 'anonymizeIp', true);` to ensure that IP addresses are collected anonymously.

<details><summary>Tracking example</summary>

 {
  "category": "resolver",
  "action": "invoke",
  "label": "javascriptUniversal"
 }
 
 {
  "category": "fetch",
  "action": "success"
 }
 
 {
  "category": "options",
  "action": "newWindow",
  "label": "false"
 }
 
 {
  "category": "options",
  "action": "showLinkIndicator",
  "label": "true"
 }
 
 {
  "category": "options",
  "action": "doTrack",
  "label": "true"
 }
 
 {
  "category": "options",
  "action": "debugMode",
  "label": "false"
 }
 
 {
  "category": "options",
  "action": "highlightLinks",
  "label": "false"
 }
 
 {
  "category": "options",
  "action": "version",
  "label": "4.6"
 }
</details>

## How we use collected information

The collected information are only used to improve the OctoLinker, nothing else.

## Opt-out

To provide you with the ability to prevent data from being tracked by us, we have added an opt-out option in the settings. If you want to opt-out,  go the extension settings page and uncheck the _Send anonymous usage reports to Google Analytics_ checkbox. 
