### PR TITLE
Fix bug where Firefoxs Pop-up blocker prevents open link in new tab

### DIFF
--- a/lib/background.js
+++ b/lib/background.js
@@ -52,9 +52,21 @@ function loader(urls, cb) {
   });
 }
 
+function newTab(url, index) {
+  chrome.tabs.create({
+    url,
+    index,
+  });
+}
+
 chrome.runtime.onMessage.addListener(({ type, payload }, sender) => {
   if (type === 'track') {
     trackEvent(payload);
+    return;
+  }
+
+  if (type === 'newTab') {
+    newTab(payload.url, sender.tab.index + 1);
     return;
   }
 

--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -18,7 +18,16 @@ function openUrl(url, newWindow = false) {
     return;
   }
 
-  window.open(url, newWindow ? '_blank' : '_self');
+  if (newWindow) {
+    chrome.runtime.sendMessage({
+      type: 'newTab',
+      payload: {
+        url,
+      },
+    });
+  } else {
+    window.location.href = url;
+  }
 }
 
 function tryLoad(urls, cb) {


### PR DESCRIPTION
Fix for #225. 

@josephfrazier I tried to write some tests for this, but unfortunately the current implementation makes it quite difficult. Basicly we have to fake/reimplement the the message system that we use to communicate with the background script. I'll work on that in a separate PR.