### PR TITLE
helper-grammar-regex-collection: Ensure PYTHON_IMPORT doesn't match comments

### DIFF
--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -7,7 +7,7 @@ const TYPESCRIPT_REFERENCE = /\/{3}\s?<reference path=['"]([^'"\s]+)['"]/g;
 const DOCKER_FROM = /FROM\s([^\n]*)/g;
 const VIM_PLUGIN = /(?:(?:(?:Neo)?Bundle(?:Lazy|Fetch)?)|Plug(?:in)?)\s['"]([^'"\s]+)['"]/g;
 const RUST_CRATE = /(?:extern crate|use) ([^:; ]+)/g;
-const PYTHON_IMPORT = /(?:(?:\n|^)\s*import|from)\s([^\s]*)/g;
+const PYTHON_IMPORT = /^\s*(?:import|from)\s([^\s]*)/gm;
 
 export {
   REQUIRE,

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -174,6 +174,7 @@ const fixtures = {
     invalid: [
       '\simport foo',
       '\simport\nfoo',
+      '# from the',
     ],
   },
 };


### PR DESCRIPTION
This is done by using the [multiline flag] instead of matching a newline,
then by moving the `^\s*` outside the non-capturing group.

Test page:
https://github.com/kewisch/pyamo/blob/38dc77a833492a22d8ff707001577489f49ba9d6/pyamo/utils.py#L81

[multiline flag]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline