### PR TITLE
Open package.json url in `npm run firefox-open`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "firefox-dist": "npm run firefox-build -- -p",
     "firefox-watch": "npm run firefox-manifest && webpack --watch",
     "firefox-pack": "npm run firefox-dist && mkdirp out && zip -rj out/firefox-octolinker-$npm_package_version.zip dist/",
-    "firefox-open": "npm run firefox-build && web-ext run --source-dir dist"
+    "firefox-open": "npm run firefox-build && web-ext run --source-dir dist --pref startup.homepage_welcome_url=https://github.com/OctoLinker/browser-extension/blob/master/package.json"
   },
   "dependencies": {
     "JSONPath": "0.11.2",


### PR DESCRIPTION
This makes it work like `npm run chrome-open`, which navigates to
https://github.com/OctoLinker/browser-extension/blob/master/package.json

See here for info about the `web-ext` flag:
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#--pref