### PR TITLE
.travis.yml: Make phantomjs less flaky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_install:
   - npm install -g npm@latest
 before_script:
   - ./packages/blob-reader/scripts/update-fixtures.sh
+script:
+  - travis_retry npm test
 before_deploy:
   - npm run package-all
 deploy:


### PR DESCRIPTION
Recently, I've been seeing more frequent Travis errors like this:

    AssertionError: ' // Most popular rabbit names' == '// Most popular rabbit names'
        at fail (webpack:///~/assert/assert.js?9281:200:0 <- test/main-packages.js:10454)
        at equal (webpack:///~/assert/assert.js?9281:224:0 <- test/main-packages.js:10478)
        at webpack:///packages/blob-reader/test.js:157:8 <- test/main-packages.js:11568

(see https://github.com/OctoLinker/browser-extension/pull/115#issuecomment-229819535)

After a little research, I found that Travis offers a [travis_retry]
function for retrying flaky commands, so I added it to the .travis.yml
file in hopes that it will resolve this annoyance. If you're curious,
here's the `travis_retry` [implementation].

[travis_retry]: https://docs.travis-ci.com/user/common-build-problems/#travis_retry
[implementation]: https://github.com/travis-ci/travis-build/blob/02fb3b35c35cb7d69dd28923404c4cc02dc57ddd/lib/travis/build/templates/header.sh#L211-L230

EDIT: Here's an example of it working: https://travis-ci.org/OctoLinker/browser-extension/builds/195003627#L739 (or https://s3.amazonaws.com/archive.travis-ci.org/jobs/195003628/log.txt)