### PR TITLE
blob-reader: Don't use reserved name in tests

### DIFF
--- a/packages/blob-reader/test.js
+++ b/packages/blob-reader/test.js
@@ -58,7 +58,7 @@ describe('blob-reader', () => {
       assert.equal(result.lines.length, 4);
     });
 
-    describe('toString', () => {
+    describe('toString()', () => {
       it('returns a string representation of the blobs content', () => {
         result.lines = [
           { value: 'a' },
@@ -68,7 +68,7 @@ describe('blob-reader', () => {
       });
     });
 
-    describe('toJSON', () => {
+    describe('toJSON()', () => {
       it('returns a JSON representation of the blobs content', () => {
         result.lines = [
           { value: '{' },


### PR DESCRIPTION
Commit d236ab7 (#251) renamed a couple of tests, but one of them
('toString') started causing warnings like the one seen in [this build].
It looks like the warning is coming from [karma-mocha-reporter], but it's
easy enough to work around by simply adding parentheses to the function
names in the test files.

[this build]: https://travis-ci.org/OctoLinker/browser-extension/builds/193866584#L538
[karma-mocha-reporter]: https://github.com/litixsoft/karma-mocha-reporter/blob/9e2f342eeac311ea9824bfd78540b177bc2d3d46/index.js#L479