### PR TITLE
package.json: Extract firefox-launch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "firefox-dist": "npm run firefox-build -- -p",
     "firefox-watch": "npm run firefox-manifest && webpack --watch",
     "firefox-pack": "npm run firefox-dist && mkdirp out && zip -rj out/firefox-octolinker-$npm_package_version.zip dist/",
-    "firefox-open": "npm run firefox-build && web-ext run --source-dir dist --pref startup.homepage_welcome_url=https://github.com/OctoLinker/browser-extension/blob/master/package.json"
+    "firefox-open": "npm run firefox-build && npm run firefox-launch --",
+    "firefox-launch": "web-ext run --source-dir dist --pref startup.homepage_welcome_url=https://github.com/OctoLinker/browser-extension/blob/master/package.json"
   },
   "dependencies": {
     "JSONPath": "0.11.2",


### PR DESCRIPTION
package.json: Extract `firefox-launch` script

This allows developers to open the extension in Firefox without
rebuilding the extension, which is useful if they have `npm run
firefox-watch` running in another shell.

The `firefox-open` script has `--` on the end so that arguments can
still be passed through it to `web-ext`, as in:

    npm run firefox-open -- --firefox=firefoxdeveloperedition

(see https://github.com/OctoLinker/browser-extension/issues/248#issuecomment-273624297)