### PR TITLE
Fix Unhandled promise rejection in storage.js

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import OctoLinker from './octo-linker.js';
 import * as storage from './options/storage.js';
 

--- a/lib/options/storage.js
+++ b/lib/options/storage.js
@@ -1,6 +1,8 @@
 import uuid from 'uuid';
+import ChromePromise from 'chrome-promise';
 import { options } from './options';
 
+const chromep = new ChromePromise();
 const store = {};
 const defaults = {};
 
@@ -11,13 +13,22 @@ options.forEach((item) => {
 export const get = key => store[key];
 
 export const set = (key, value) => {
-  (chrome.storage.sync || chrome.storage.local).set({
+  const data = {
     [key]: value,
-  });
+  };
+
+  // Firefox 51.0.1 doesn't have storage.sync, so wrap the property access in a
+  // Promise so that the exception can be handled.
+  return new Promise(resolve => resolve(chromep.storage.sync.set(data)))
+    .catch(() => chromep.storage.local.set(data));
 };
 
 export const load = (cb) => {
-  (chrome.storage.sync || chrome.storage.local).get(null, (data) => {
+  // Firefox 51.0.1 doesn't have storage.sync, so wrap the property access in a
+  // Promise so that the exception can be handled.
+  new Promise(resolve => resolve(chromep.storage.sync.get(null)))
+  .catch(() => chromep.storage.local.get(null))
+  .then((data) => {
     Object.assign(store, defaults, data);
 
     if (!store.clientId) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1847,6 +1847,11 @@
       "resolved": "https://registry.npmjs.org/chrome-location/-/chrome-location-1.2.1.tgz",
       "dev": true
     },
+    "chrome-promise": {
+      "version": "2.0.2",
+      "from": "https://registry.npmjs.org/chrome-promise/-/chrome-promise-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/chrome-promise/-/chrome-promise-2.0.2.tgz"
+    },
     "chrome-webstore-upload": {
       "version": "0.2.1",
       "from": "chrome-webstore-upload@>=0.2.0 <0.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "JSONPath": "0.11.2",
     "babel-polyfill": "6.22.0",
     "builtins": "1.0.3",
+    "chrome-promise": "2.0.2",
     "escape-regex-string": "1.0.4",
     "findandreplacedomtext": "0.4.5",
     "github-injection": "0.3.0",


### PR DESCRIPTION
(this is built upon https://github.com/OctoLinker/browser-extension/pull/257 to make development easier)

See https://github.com/OctoLinker/browser-extension/issues/248

I decided to use [chrome-promise] instead of [chrome-storage-wrapper] or [chrome-storage-promise], because it is more popular and better maintained.

The commit messages have more detail, but to summarize: this doesn't quite work yet, seemingly due to some strange errors potentially related to the way the `chrome.storage` functions get wrapped into returning Promises (the same thing happens with the `chrome-storage-*` packages, for what it's worth):

<details>

```
16:09:28.308 Unhandled promise rejection TypeError: promise.then is not a function
Stack trace:
wrapPromise/<@resource://gre/modules/ExtensionCommon.jsm:328:9
Promise@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4260:8
wrapPromise@resource://gre/modules/ExtensionCommon.jsm:327:14
callAsyncFunction@resource://gre/modules/ExtensionCommon.jsm:505:12
inject/</stub@resource://gre/modules/Schemas.jsm:1696:18
load/<@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:18747:12
notify/</run@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4156:23
notify/<@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4169:29
module.exports/flush@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4524:10
MutationCallback*module.exports@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4543:6
@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4082:27
__webpack_require__@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:20:12
@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:213:2
__webpack_require__@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:20:12
@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:74:2
@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:72:30
__webpack_require__@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:20:12
@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:49:2
__webpack_require__@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:20:12
@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:40:18
@file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:1:11
 1 app.js:4186:12
	onUnhandled/</abrupt< file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4186:12
	perform file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4128:6
	onUnhandled/< file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4180:17
	module.exports file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:1653:26
	<anonymous> file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4457:8
	run file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4445:6
	listener file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4449:4
	(Async: EventHandlerNonNull)
	<anonymous> file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4474:6
	__webpack_require__ file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:20:12
	<anonymous> file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:4081:27
	__webpack_require__ file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:20:12
	<anonymous> file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:213:2
	__webpack_require__ file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:20:12
	<anonymous> file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:74:2
	<anonymous> file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:72:30
	__webpack_require__ file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:20:12
	<anonymous> file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:49:2
	__webpack_require__ file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:20:12
	<anonymous> file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:40:18
	<anonymous> file:///Users/josephfrazier/workspace/octolinker/browser-extension/dist/app.js:1:11
```

</details>


I might instead look into using [webextension-polyfill], which seems to be a little more comprehensive.

[webextension-polyfill]: https://github.com/mozilla/webextension-polyfill
[chrome-promise]: https://www.npmjs.com/package/chrome-promise
[chrome-storage-wrapper]: https://www.npmjs.com/package/chrome-storage-wrapper
[chrome-storage-promise]: https://www.npmjs.com/package/chrome-storage-promise

---

If anyone else would like to have a go at this, you can reproduce the issue with:

    npm run firefox-open -- --firefox=firefoxdeveloperedition