### PR TITLE
.appveyor.yml: Retry Chocolatey installs and PhantomJS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,8 +9,8 @@ cache:
 install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
-  - choco install phantomjs
-  - choco install zip
+  - appveyor-retry choco install phantomjs
+  - appveyor-retry choco install zip
   # install modules
   - npm install
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ test_script:
   - npm run package-all
   # run tests
   - set PHANTOMJS_BIN=C:\ProgramData\chocolatey\bin\phantomjs.exe
-  - npm test
+  - appveyor-retry call npm test
 
 # Don't actually build.
 build: off


### PR DESCRIPTION
This adds an `appveyor-retry` wrapper around parts of the AppVeyor build
that have intermittently failed in the past. Here are some example
failures:

* https://ci.appveyor.com/project/josephfrazier/browser-extension/build/1.0.44
* https://ci.appveyor.com/project/stefanbuck/browser-extension/build/1.0.177

See the commit messages for more details.