### PR TITLE
Add .npmrc with save-exact=true

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
This makes it so developers won't have to type `--save-exact` when
running `npm install`, to keep package.json versions pinned. See d1c6b70
for context.

Note that `--no-optional` is still needed to avoid having `fsevents`
sneak back into npm-shrinkwrap.json. There doesn't seem to be a .npmrc
config for that.