### PR TITLE
Use `uuid` instead of `node-uuid`

### DIFF
--- a/lib/options/storage.js
+++ b/lib/options/storage.js
@@ -1,4 +1,4 @@
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import { options } from './options';
 
 const store = {};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4466,8 +4466,9 @@
     },
     "node-uuid": {
       "version": "1.4.7",
-      "from": "node-uuid@1.4.7",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+      "from": "node-uuid@>=1.4.7 <1.5.0",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.3.5",
@@ -5969,8 +5970,7 @@
     "uuid": {
       "version": "2.0.3",
       "from": "uuid@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "github-url-from-username-repo": "1.0.2",
     "giturl": "1.0.0",
     "jquery": "3.1.1",
-    "node-uuid": "1.4.7",
     "querystring": "0.2.0",
     "semver": "5.3.0",
-    "semver-regex": "1.0.0"
+    "semver-regex": "1.0.0",
+    "uuid": "2.0.3"
   },
   "devDependencies": {
     "babel-core": "6.22.1",


### PR DESCRIPTION
This avoids the following deprecation warning upon `npm install`:

    npm WARN deprecated node-uuid@1.4.7: use uuid module instead

`web-ext` still uses `node-uuid` indirectly (via `sign-addon` -> `request`),
but I'm working on fixing that too. See https://github.com/mozilla/sign-addon/pull/245