### PR TITLE
Remove pre-commit hook

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -183,7 +183,7 @@
         "glob": {
           "version": "7.1.1",
           "from": "glob@>=7.0.0 <8.0.0",
-          "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "dev": true
         }
       }
@@ -197,7 +197,7 @@
         "glob": {
           "version": "7.1.1",
           "from": "glob@>=7.0.0 <8.0.0",
-          "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "dev": true
         }
       }
@@ -1859,12 +1859,6 @@
       "resolved": "https://registry.npmjs.org/chrome-webstore-upload-cli/-/chrome-webstore-upload-cli-1.1.1.tgz",
       "dev": true
     },
-    "ci-info": {
-      "version": "1.0.0",
-      "from": "ci-info@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
-      "dev": true
-    },
     "circular-json": {
       "version": "0.3.1",
       "from": "circular-json@>=0.3.0 <0.4.0",
@@ -2887,12 +2881,6 @@
       "resolved": "http://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "dev": true
     },
-    "find-parent-dir": {
-      "version": "0.3.0",
-      "from": "find-parent-dir@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
-      "dev": true
-    },
     "find-up": {
       "version": "1.1.2",
       "from": "find-up@>=1.0.0 <2.0.0",
@@ -3207,7 +3195,7 @@
         "glob": {
           "version": "7.1.1",
           "from": "glob@>=7.0.3 <8.0.0",
-          "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "dev": true
         }
       }
@@ -3340,20 +3328,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "dev": true
     },
-    "husky": {
-      "version": "0.13.1",
-      "from": "husky@0.13.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-0.13.1.tgz",
-      "dev": true,
-      "dependencies": {
-        "normalize-path": {
-          "version": "1.0.0",
-          "from": "normalize-path@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
-          "dev": true
-        }
-      }
-    },
     "iconv-lite": {
       "version": "0.4.15",
       "from": "iconv-lite@0.4.15",
@@ -3466,12 +3440,6 @@
       "version": "1.1.3",
       "from": "is-callable@>=1.1.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "dev": true
-    },
-    "is-ci": {
-      "version": "1.0.10",
-      "from": "is-ci@>=1.0.9 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "dev": true
     },
     "is-date-object": {
@@ -5191,7 +5159,7 @@
         "glob": {
           "version": "7.1.1",
           "from": "glob@>=7.0.5 <8.0.0",
-          "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   },
   "main": "lib/app.js",
   "scripts": {
-    "precommit": "npm run lint",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test": "karma start",
@@ -56,7 +55,6 @@
     "eslint": "3.14.0",
     "eslint-config-airbnb-base": "11.0.1",
     "eslint-plugin-import": "2.2.0",
-    "husky": "0.13.1",
     "json": "9.0.4",
     "json-loader": "0.5.4",
     "karma": "1.4.0",


### PR DESCRIPTION
I often use commits to save work-in-progress, with the intention of
revising them later. Removing the pre-commit hook makes this faster.

Since `npm run lint` is also in the `pretest` script, it will still be
run on `npm test`, which should be done anyway before opening a pull
request.