### PR TITLE
Fix go package imports

### DIFF
--- a/lib/resolver/go-universal.js
+++ b/lib/resolver/go-universal.js
@@ -1,10 +1,34 @@
 import goFile from './go-file.js';
 
+function githubUrls(url) {
+  const [, user, repo, ...path] = url.split('/');
+
+  if (!path.length) {
+    return [
+      `{BASE_URL}/${user}/${repo}/blob/master/${repo}.go`,
+      `{BASE_URL}/${user}/${repo}`,
+    ];
+  }
+
+  const fullPath = path.join('/');
+  const last = path.slice(-1);
+
+  return [
+    `{BASE_URL}/${user}/${repo}/blob/master/${fullPath}/${last}.go`,
+    `{BASE_URL}/${user}/${repo}/tree/master/${fullPath}`,
+    `{BASE_URL}/${user}/${repo}`,
+  ];
+}
+
 export default function ({ target, path }) {
   const isPath = !!target.match(/^\.\.?[\\|\/]?/);
 
   if (isPath) {
     return goFile({ path, target });
+  }
+
+  if (target.startsWith('github.com')) {
+    return githubUrls(target);
   }
 
   return [

--- a/test/resolver/go-universal.test.js
+++ b/test/resolver/go-universal.test.js
@@ -1,0 +1,48 @@
+import assert from 'assert';
+import goUniversal from '../../lib/resolver/go-universal.js';
+
+describe('go-universal', () => {
+  const path = 'octo/dog.go';
+
+  it('resolves local file', () => {
+    assert.deepEqual(
+      goUniversal({ path, target: '../foo' }),
+      [
+        '{BASE_URL}foo/foo.go',
+        '{BASE_URL}foo.go',
+        '{BASE_URL}foo',
+      ],
+    );
+  });
+
+  it('resolves package', () => {
+    assert.deepEqual(
+      goUniversal({ path, target: 'foo' }),
+      [
+        'https://foo',
+        'https://golang.org/pkg/foo',
+      ],
+    );
+  });
+
+  it('resolves github shorthand', () => {
+    assert.deepEqual(
+      goUniversal({ path, target: 'github.com/foo/bar' }),
+      [
+        '{BASE_URL}/foo/bar/blob/master/bar.go',
+        '{BASE_URL}/foo/bar',
+      ],
+    );
+  });
+
+  it('resolves github deep link', () => {
+    assert.deepEqual(
+      goUniversal({ path, target: 'github.com/foo/bar/baze' }),
+      [
+        '{BASE_URL}/foo/bar/blob/master/baze/baze.go',
+        '{BASE_URL}/foo/bar/tree/master/baze',
+        '{BASE_URL}/foo/bar',
+      ],
+    );
+  });
+});


### PR DESCRIPTION
While testing the go implementation, I've noticed that some imports doesn't work. I thought that go  reference repo like `github.com/foo/bar` only. I didn't know that you can also import packages form your project like `github.com/foo/bar/baz`. This should point to `https://github.com/foo/bar/tree/master/baz` or `https://github.com/foo/bar/blob/master/baz/baz.go`. 
