### PR TITLE
.appveyor.yml: Update npm to latest version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,7 @@ install:
   - appveyor-retry choco install phantomjs
   - appveyor-retry choco install zip
   # install modules
+  - npm install -g npm@latest
   - npm install
 
 # Post-install test scripts.


### PR DESCRIPTION
In https://github.com/OctoLinker/browser-extension/pull/268, there was a
commit that added `eslint-plugin-mocha` to package.json, but not to
npm-shrinkwrap.json. The [Travis build] failed, as expected, but the
[AppVeyor build] passed.

I'm guessing this is because it was using an older version of `npm` that
perhaps doesn't enforce the shrinkwrap as rigorously as the latest
version. Even if that's not the case, this change will make the AppVeyor
build more similar to the Travis build, which is always good.

[Travis build]: https://travis-ci.org/OctoLinker/browser-extension/builds/196900691#L453
[AppVeyor build]: https://ci.appveyor.com/project/stefanbuck/browser-extension/build/1.0.206