### PR TITLE
javascript-file: Don't strip extension from file names

### DIFF
--- a/lib/resolver/javascript-file.js
+++ b/lib/resolver/javascript-file.js
@@ -3,20 +3,11 @@ import { join, dirname, extname } from 'path';
 export default function ({ path, target }) {
   const list = [];
   const extName = ['.js', '.jsx', '.ts', '.tsx', '.json'];
-  let basePath = join(dirname(path), target);
+  const basePath = join(dirname(path), target);
   const pathExt = extname(path);
-  const fileExt = extname(basePath);
-
-  if (fileExt) {
-    basePath = basePath.replace(fileExt, '');
-  }
 
   if (pathExt && !extName.includes(pathExt)) {
     extName.unshift(pathExt);
-  }
-
-  if (fileExt && !extName.includes(fileExt)) {
-    extName.unshift(fileExt);
   }
 
   extName.forEach((ext) => {

--- a/lib/resolver/javascript-file.js
+++ b/lib/resolver/javascript-file.js
@@ -1,10 +1,18 @@
 import { join, dirname, extname } from 'path';
 
-export default function ({ path, target }) {
+function resolve({ path, target }) {
   const list = [];
   const extName = ['.js', '.jsx', '.ts', '.tsx', '.json'];
   const basePath = join(dirname(path), target);
   const pathExt = extname(path);
+  const fileExt = extname(basePath);
+
+  if (extName.includes(fileExt)) {
+    return resolve({
+      path,
+      target: target.replace(fileExt, ''),
+    });
+  }
 
   if (pathExt && !extName.includes(pathExt)) {
     extName.unshift(pathExt);
@@ -19,3 +27,5 @@ export default function ({ path, target }) {
 
   return list.map(file => `{BASE_URL}${basePath}${file}`);
 }
+
+export default resolve;

--- a/test/resolver/javascript-universal.test.js
+++ b/test/resolver/javascript-universal.test.js
@@ -27,4 +27,23 @@ describe('javascript-universal', () => {
       'https://nodejs.org/api/modules.html',
     );
   });
+
+  it("resolves './modules/es6.symbol' without stripping .symbol suffix", () => {
+    assert.deepEqual(
+      javascriptUniversal({ target: './modules/es6.symbol' }),
+      [
+        '{BASE_URL}modules/es6.symbol.js',
+        '{BASE_URL}modules/es6.symbol/index.js',
+        '{BASE_URL}modules/es6.symbol.jsx',
+        '{BASE_URL}modules/es6.symbol/index.jsx',
+        '{BASE_URL}modules/es6.symbol.ts',
+        '{BASE_URL}modules/es6.symbol/index.ts',
+        '{BASE_URL}modules/es6.symbol.tsx',
+        '{BASE_URL}modules/es6.symbol/index.tsx',
+        '{BASE_URL}modules/es6.symbol.json',
+        '{BASE_URL}modules/es6.symbol/index.json',
+        '{BASE_URL}modules/es6.symbol',
+      ],
+    );
+  });
 });

--- a/test/resolver/javascript-universal.test.js
+++ b/test/resolver/javascript-universal.test.js
@@ -46,4 +46,23 @@ describe('javascript-universal', () => {
       ],
     );
   });
+
+  it("resolves './modules/es6.symbol.js' like './modules/es6.symbol'", () => {
+    assert.deepEqual(
+      javascriptUniversal({ target: './modules/es6.symbol.js' }),
+      [
+        '{BASE_URL}modules/es6.symbol.js',
+        '{BASE_URL}modules/es6.symbol/index.js',
+        '{BASE_URL}modules/es6.symbol.jsx',
+        '{BASE_URL}modules/es6.symbol/index.jsx',
+        '{BASE_URL}modules/es6.symbol.ts',
+        '{BASE_URL}modules/es6.symbol/index.ts',
+        '{BASE_URL}modules/es6.symbol.tsx',
+        '{BASE_URL}modules/es6.symbol/index.tsx',
+        '{BASE_URL}modules/es6.symbol.json',
+        '{BASE_URL}modules/es6.symbol/index.json',
+        '{BASE_URL}modules/es6.symbol',
+      ],
+    );
+  });
 });


### PR DESCRIPTION
fixes https://github.com/OctoLinker/browser-extension/issues/271

This allows paths like `./modules/es6.symbol` to correctly resolve to
`./modules/es6.symbol.js`

For example: https://github.com/zloirock/core-js/blob/0bb657cfc7834d03fd68c48a1cba70f2ccab20c0/shim.js#L1

EDIT:

Removing the `fileExt` code didn't break any tests, but I'm not sure if it breaks any functionality in practice. @stefanbuck, do you know why it was there?