### PR TITLE
Automatically fix lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "main": "lib/app.js",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint . --fix",
     "pretest": "npm run lint",
     "test": "karma start",
     "test:watch": "karma start --no-single-run --auto-watch",


### PR DESCRIPTION
This uses eslint's [--fix] flag to repair minor code style issues on the
fly. Note that this flag is very [conservative], so it shouldn't cause any
problems.

[--fix]: http://eslint.org/docs/user-guide/command-line-interface#fix
[conservative]: https://github.com/eslint/eslint/issues/7873#issuecomment-271701235

EDIT: Actually, I just realized that since the `lint` script runs as part of `npm test`, this would cause Travis to allow style errors. I'll think about a better way to have autofixing locally, but not on CI