### PR TITLE
Move Babel settings from webpack.config.js to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,14 @@
     "firefox-open": "npm run firefox-build && npm run firefox-launch --",
     "firefox-launch": "web-ext run --source-dir dist --pref startup.homepage_welcome_url=https://github.com/OctoLinker/browser-extension/blob/master/package.json"
   },
+  "babel": {
+    "plugins": [
+      "transform-object-rest-spread"
+    ],
+    "presets": [
+      "es2015"
+    ]
+  },
   "dependencies": {
     "JSONPath": "0.11.2",
     "builtins": "1.0.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,10 +24,6 @@ module.exports = {
         test: /\.js$/,
         exclude: /(node_modules)/,
         loader: 'babel-loader',
-        query: {
-          plugins: ['transform-object-rest-spread'],
-          presets: ['es2015'],
-        },
       },
     ],
   },


### PR DESCRIPTION
This makes it possible for other tools to use the Babel settings. For
example, `babel-node` can be used during development as a REPL with
files in the repo:

    $ babel-node -p "require('./packages/helper-grammar-regex-collection/regex.js')"
    { default: [Function] }