### PR TITLE
Fix private repo handling

### DIFF
--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -51,6 +51,7 @@ function tryLoad(urls, cb) {
 
 function getResolverUrls(dataAttr) {
   const resolverStrings = dataAttr.resolver.replace(/\s/g, '').split('|');
+  const BASE_URL = 'https://github.com';
 
   const urls = resolverStrings.map((resolverName) => {
     const resolver = resolverHandlers.get(resolverName);
@@ -71,14 +72,14 @@ function getResolverUrls(dataAttr) {
 
         if (typeof url === 'object') {
           return {
-            url: url.url.replace('{BASE_URL}', 'https://github.com'),
+            url: url.url.replace('{BASE_URL}', BASE_URL),
             method: url.method,
           };
         }
 
-        if (url.startsWith('{BASE_URL}')) {
+        if (url.startsWith('{BASE_URL}') || url.startsWith(BASE_URL)) {
           return {
-            url: url.replace('{BASE_URL}', 'https://github.com'),
+            url: url.replace('{BASE_URL}', BASE_URL),
           };
         }
 

--- a/test/click-handler.test.js
+++ b/test/click-handler.test.js
@@ -123,6 +123,17 @@ describe('click-handler', () => {
       });
     });
 
+    describe('when url start with "https://github.com"', () => {
+      it('does not call the ping route for github.com', () => {
+        resolvers.foo.returns(['https://github.com/foo']);
+        $link.click();
+
+        assert.deepEqual(window.chrome.runtime.sendMessage.args[1][0].payload, [
+          { url: 'https://github.com/foo' },
+        ]);
+      });
+    });
+
     describe('when url does not start with "https://github.com"', () => {
       it('calls the ping route with the given given url', () => {
         resolvers.foo.returns(['https://hubhub.com/foo']);


### PR DESCRIPTION
The resolver result url of a git-url or github shorthand was causing a ping call to our live-resolver server. By nature, this service can not reach private repo which ends in 404 response. It was working in a previous version, but #174 broke this behaviour.