### PR TITLE
helper-grammar-regex-collection: prevent RUST_CRATE from matching partial

### DIFF
--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -62,7 +62,7 @@ const VIM_PLUGIN = regex`
 `;
 
 const RUST_CRATE = regex`
-  (extern \s crate | use)
+  \b (extern \s crate | use)
   \s
   (?<$1>[^:;\s]+)
 `;

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -162,6 +162,7 @@ const fixtures = {
     ],
     invalid: [
       "extern create 'pcre'",
+      'because it',
     ],
   },
   PYTHON_IMPORT: {


### PR DESCRIPTION
This partially addresses
https://github.com/OctoLinker/browser-extension/issues/284 by preventing
text like "because it" from being linked as if "use it" referred to a
Rust crate.