### PR TITLE
Ignre checksums when installing chrome from choco

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   - appveyor-retry choco install firefox
-  - appveyor-retry choco install googlechrome
+  - appveyor-retry choco install googlechrome --ignore-checksums
   - appveyor-retry choco install phantomjs
   - appveyor-retry choco install zip
   # install modules


### PR DESCRIPTION

```
Downloading googlechrome 64 bit
  from 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi'
Progress: 100% - Completed download of C:\Users\appveyor\AppData\Local\Temp\1\chocolatey\GoogleChrome\56.0.2924.87\googlechromestandaloneenterprise64.msi (48.26 MB).
Download of googlechromestandaloneenterprise64.msi (48.26 MB) completed.
Error - hashes do not match. Actual value was '1450DE87F0289CE725DF1C138BBA2666304FB94BF4476B03C06D058C999D4805'.
ERROR: Checksum for 'C:\Users\appveyor\AppData\Local\Temp\1\chocolatey\GoogleChrome\56.0.2924.87\googlechromestandaloneenterprise64.msi' did not meet 'c47ff551ff8b251268905cd87fb299959e6bcb3640a3e60085a3a7dbf176845f' for checksum type 'sha256'. Consider passing --ignore-checksums if necessary.
The install of googlechrome was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\GoogleChrome\tools\chocolateyInstall.ps1'.
 See log for details.
Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
Failures
 - googlechrome (exited -1) - Error while running 'C:\ProgramData\chocolatey\lib\GoogleChrome\tools\chocolateyInstall.ps1'.
 See log for details.
Did you know the proceeds of Pro (and some proceeds from other 
```