### PR TITLE
Add option to open tabs in background

### DIFF
--- a/lib/background/newTab.js
+++ b/lib/background/newTab.js
@@ -1,7 +1,8 @@
-function newTab(url, index) {
+function newTab(url, index, active) {
   chrome.tabs.create({
     url,
     index,
+    active,
   });
 }
 
@@ -9,6 +10,6 @@ export default () => {
   chrome.runtime.onMessage.addListener(({ type, payload }, sender) => {
     if (type !== 'newTab') return;
 
-    newTab(payload.url, sender.tab.index + 1);
+    newTab(payload.url, sender.tab.index + 1, payload.active);
   });
 };

--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -12,7 +12,7 @@ let pluginManager;
 
 let hasEventListener = false;
 
-function openUrl(url, newWindow = false) {
+function openUrl(url, newWindow = false, newWindowActive = true) {
   if (!url) {
     return;
   }
@@ -22,6 +22,7 @@ function openUrl(url, newWindow = false) {
       type: 'newTab',
       payload: {
         url,
+        active: newWindowActive,
       },
     });
   } else {
@@ -119,7 +120,8 @@ function onClick(event) {
     showTooltip($tooltipTarget, RESOLVED);
 
     const newWindow = (storage.get('newWindow') || event.metaKey || event.ctrlKey || event.which === 2);
-    openUrl((res || {}).url || url, newWindow);
+    const newWindowActive = storage.get('newWindowActive');
+    openUrl((res || {}).url || url, newWindow, newWindowActive);
   });
 }
 

--- a/lib/options/options.js
+++ b/lib/options/options.js
@@ -8,6 +8,13 @@ export const options = [
   },
   {
     type: 'checkbox',
+    name: 'newWindowActive',
+    label: 'Focus new tabs',
+    value: undefined,
+    defaultValue: true,
+  },
+  {
+    type: 'checkbox',
     name: 'showLinkIndicator',
     label: 'Show indicator if line contains OctoLinker links',
     value: undefined,


### PR DESCRIPTION
This lets the user specify the `active` argument to
[chrome.tabs.create]. If they uncheck the option, new tabs will open in
the background, rather than becoming focused. However, it defaults to
checked, which preserves the current behavior of focusing new tabs.

[chrome.tabs.create]: https://developer.chrome.com/extensions/tabs#method-create