### PR TITLE
Add HTML import support

### DIFF
--- a/lib/pattern-preset.js
+++ b/lib/pattern-preset.js
@@ -92,6 +92,16 @@ export const presets = {
       'highlight-source-css',
     ],
   },
+
+  html: {
+    pathSubstrings: [
+      '.html',
+      '.htm',
+    ],
+    githubClasses: [
+      'type-html',
+    ],
+  },
 };
 
 export default function (presetName, siblingPresetName) {

--- a/lib/plugins/html.js
+++ b/lib/plugins/html.js
@@ -1,0 +1,25 @@
+import { HTML_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
+import insertLink from '../insert-link';
+import preset from '../pattern-preset';
+import relativeFile from '../resolver/relative-file.js';
+
+export default class HTML {
+
+  static resolve({ target, path }) {
+    return [
+      relativeFile({ path, target }),
+    ];
+  }
+
+  getPattern() {
+    return preset('html');
+  }
+
+  parseBlob(blob) {
+    insertLink(blob.el, HTML_IMPORT, {
+      pluginName: this.constructor.name,
+      target: '$1',
+      path: blob.path,
+    });
+  }
+}

--- a/packages/blob-reader/fixtures/github.com/issue/code.html
+++ b/packages/blob-reader/fixtures/github.com/issue/code.html
@@ -11,7 +11,7 @@
 
 
 
-  <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/frameworks-6718b56fbb752ac1a583c95f00f5efc2a162aaed40e413df4506f4e5b9792996.css" media="all" rel="stylesheet" />
+  <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/frameworks-19e26a1cefb5f1e92203a9468134dbf46b5a5308aeeeee09c96b32fec8c8b044.css" media="all" rel="stylesheet" />
   <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github-a97f6b98170262f1be5dd5b84d3fb788f1bb65b269c11417026fe763d5eeb63b.css" media="all" rel="stylesheet" />
   
   
@@ -49,7 +49,7 @@ package.json
   
   <meta name="pjax-timeout" content="1000">
   
-  <meta name="request-id" content="C29F:4E97:1B2CA32:2C2A161:58BC74F5" data-pjax-transient>
+  <meta name="request-id" content="EA52:3E1A:2054DC:3375AF:58BDEC47" data-pjax-transient>
   
 
   <meta name="selected-link" value="repo_issues" data-pjax-transient>
@@ -58,8 +58,9 @@ package.json
 <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
     <meta name="google-analytics" content="UA-3769691-2">
 
-<meta content="collector.githubapp.com" name="octolytics-host" /><meta content="github" name="octolytics-app-id" /><meta content="https://collector.githubapp.com/github-external/browser_event" name="octolytics-event-url" /><meta content="C29F:4E97:1B2CA32:2C2A161:58BC74F5" name="octolytics-dimension-request_id" />
+<meta content="collector.githubapp.com" name="octolytics-host" /><meta content="github" name="octolytics-app-id" /><meta content="https://collector.githubapp.com/github-external/browser_event" name="octolytics-event-url" /><meta content="EA52:3E1A:2054DC:3375AF:58BDEC47" name="octolytics-dimension-request_id" />
 <meta content="/&lt;user-name&gt;/&lt;repo-name&gt;/issues/show" data-pjax-transient="true" name="analytics-location" />
+
 
 
 
@@ -71,12 +72,12 @@ package.json
   <meta name="user-login" content="">
 
       <meta name="expected-hostname" content="github.com">
-    <meta name="js-proxy-site-detection-payload" content="MmFiOTY0MjNjYWVmZWZkZWY2NDYzNTk5MGZmZDM2YzIzODU1YjU4YzQwZWFkNWU5YTQ5NjNhNGQwZjg4ZGYwN3x7InJlbW90ZV9hZGRyZXNzIjoiMTA5LjE5Mi43NS41MyIsInJlcXVlc3RfaWQiOiJDMjlGOjRFOTc6MUIyQ0EzMjoyQzJBMTYxOjU4QkM3NEY1IiwidGltZXN0YW1wIjoxNDg4NzQ1NzE4LCJob3N0IjoiZ2l0aHViLmNvbSJ9">
+    <meta name="js-proxy-site-detection-payload" content="NWU5YzgxYmU1MzAxZjc3YWRmNjY3NjA3ZDIwZWNjMzA2MjY5MjZlNGEyNWE0ZDFiNTY0ZjlmYmZmYWM1MWY0M3x7InJlbW90ZV9hZGRyZXNzIjoiMTA5LjE5Mi43NS41MyIsInJlcXVlc3RfaWQiOiJFQTUyOjNFMUE6MjA1NERDOjMzNzVBRjo1OEJERUM0NyIsInRpbWVzdGFtcCI6MTQ4ODg0MTc5OSwiaG9zdCI6ImdpdGh1Yi5jb20ifQ==">
 
 
-  <meta name="html-safe-nonce" content="700cf90b102169cc7db124bcc7dc394db2e44da0">
+  <meta name="html-safe-nonce" content="94beeb4bb1626580d1abbfccd0ec5e838c12bd18">
 
-  <meta http-equiv="x-pjax-version" content="dc5b71228a97b330f4c8330ad3bfb8a1">
+  <meta http-equiv="x-pjax-version" content="6f7dd5e8045db8184cd083c6d969fed2">
   
 
     
@@ -360,7 +361,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
   data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Fsidebar">
 
   <div class="discussion-sidebar-item sidebar-assignee js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Fassignees" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="GRiChJLmohm8XE7Qr1cT222hIgeOQcSAQo3WylWYz1uITY068dh5Ms4DwrOUtxH/EZfmq/ABhlZvl/E7uWEzOA==" /></div>
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Fassignees" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="Cc8nkt9N/MtqNc9ZCHFwgXjU7Po23rlC5nxcabdcd2riTq8Knp97Yd+wM/GtSnRFSWwAtWlatVZa5g/l5VnZug==" /></div>
     
   <h3 class="discussion-sidebar-heading">
     Assignees
@@ -374,7 +375,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 </form></div>
 
   <div class="discussion-sidebar-item sidebar-labels js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Flabels" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="XZ8FcF0fW6l7szxfedTIW2NdFcdwjUGKouu051Q5AYfMygrOPiGAggnssDxCNMp/H2vRaw7NA1yP8ZMWuMD95A==" /></div>
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Flabels" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="QYUY1PnxpMCjIF/fHQcjK+eaTb9IISP8n8vzNV90c+qqBJBMuCMjahalo3e4PCfv1iKh8BelL+gjUaC5DXHdOg==" /></div>
       
   <h3 class="discussion-sidebar-heading">
     Labels
@@ -388,7 +389,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 </form></div>
 
   <div class="discussion-sidebar-item js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/projects/issues/2" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="odxY1PnsWnjrd61bexbZWq3xdKSkuX/tnHYTwLjxsqfJz7V+Lx4ds7t4x4tSQFbeVREbmA+DNM3kxR6YAbsHLQ==" /></div>
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/projects/issues/2" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="6ZrOO53AXzq1TSH7w0eTU6pSxZuujPK/IlgW1MCYJ96ajAkfhKEln1VEm6u/e3+nKuz+eu9ZtEb4zMWlgABMDg==" /></div>
     
   <h3 class="discussion-sidebar-heading">
     Projects
@@ -402,7 +403,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 </form></div>
 
   <div class="discussion-sidebar-item sidebar-milestone js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2/set_milestone?partial=issues%2Fsidebar%2Fshow%2Fmilestone" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="p0Nbis2A2H1FVRjp0jdwuz1YBCidKoRkeXj//UApIUYsz+WLNGFYHolYVSAJhQGpD6f53CN4w9bRWAvSDBfcTg==" /></div>
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2/set_milestone?partial=issues%2Fsidebar%2Fshow%2Fmilestone" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="Qv7Uazpt/XL6+k0BwGfz01aeSyQCKfwEafnk0+FSBfsLxuSsNY2mUceOGf14kZef8fpX1x3va8IWz98dQMQPHQ==" /></div>
     
   <h3 class="discussion-sidebar-heading">
     Milestone
@@ -446,7 +447,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
      class="comment previewable-edit timeline-comment js-comment js-task-list-container
                     
                       "
-     data-body-version="c6fbe17689f806ccab5176c18e75b469">
+     data-body-version="74deb34c04c4ec6c391f836953f4cae7">
 
   
 <div class="timeline-comment-header ">
@@ -474,7 +475,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
       &#8226;
       <span class="timestamp timestamp-edited tooltipped tooltipped-n"
-            aria-label="stefanbuck edited this issue about 4 hours ago">
+            aria-label="stefanbuck edited this issue less than a minute ago">
         edited
       </span>
   </div>
@@ -520,6 +521,9 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/vim-poslist.git<span class="pl-pds">"</span></span></pre></div>
 <div class="highlight highlight-source-go"><pre><span class="pl-k">import</span> <span class="pl-s"><span class="pl-pds">"</span>os<span class="pl-pds">"</span></span></pre></div>
 <div class="highlight highlight-source-css"><pre><span class="pl-k">@import</span> <span class="pl-s"><span class="pl-pds">"</span>os<span class="pl-pds">"</span></span></pre></div>
+<div class="highlight highlight-source-css-less"><pre><span class="pl-k">@import</span> <span class="pl-s"><span class="pl-pds">"</span>os<span class="pl-pds">"</span></span></pre></div>
+<div class="highlight highlight-source-sass"><pre><span class="pl-k">@import</span> <span class="pl-s">"os"</span></pre></div>
+<div class="highlight highlight-text-html-basic"><pre>&lt;<span class="pl-ent">link</span> <span class="pl-e">rel</span>=<span class="pl-s"><span class="pl-pds">"</span>import<span class="pl-pds">"</span></span> <span class="pl-e">href</span>=<span class="pl-s"><span class="pl-pds">"</span>foo.html<span class="pl-pds">"</span></span>&gt;</pre></div>
           </td>
         </tr>
       </tbody>
@@ -542,14 +546,14 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 
 
 
-<!-- Rendered timeline since 2017-03-05 08:33:27 -->
+<!-- Rendered timeline since 2017-03-06 15:09:33 -->
 <div id="partial-timeline-marker"
       class="js-timeline-marker js-socket-channel js-updatable-content"
       data-channel="tenant:1:issue:185246647"
-      data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Ftimeline_marker&amp;since=1488731607"
-      data-last-modified="Sun, 05 Mar 2017 16:33:27 GMT">
+      data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Ftimeline_marker&amp;since=1488841773"
+      data-last-modified="Mon, 06 Mar 2017 23:09:33 GMT">
 
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/notifications/mark?ids=176302197" class="d-none js-timeline-marker-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="3YMiPerUdpB6UmZ6azXuhpcLuDV8L9Vzapwa0znoOI75C48birgDINJ3OK4/NJaxyw14WcxAgAwddX6bQaQmtg==" /></div>
+    <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/notifications/mark?ids=176302197" class="d-none js-timeline-marker-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="8M0+HuOgC/fuKkylHyPGsh4lHn3flunH6sYMpT/BSdQqTpMYNMSe5D55f47EfoKJXa9pBGChD2lCTf4Y1u3ePg==" /></div>
 </form></div>
 
 
@@ -599,7 +603,7 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
       <svg aria-hidden="true" class="octicon octicon-mark-github" height="24" version="1.1" viewBox="0 0 16 16" width="24"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
 </a>
     <ul class="site-footer-links">
-      <li>&copy; 2017 <span title="0.16953s from github-fe137-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
+      <li>&copy; 2017 <span title="0.12153s from github-fe165-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
         <li><a href="https://github.com/site/terms" data-ga-click="Footer, go to terms, text:terms">Terms</a></li>
         <li><a href="https://github.com/site/privacy" data-ga-click="Footer, go to privacy, text:privacy">Privacy</a></li>
         <li><a href="https://github.com/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
@@ -623,8 +627,8 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 
 
     <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/compat-8e19569aacd39e737a14c8515582825f3c90d1794c0e5539f9b525b8eb8b5a8e.js"></script>
-    <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-506169cb2fe76254b921e8c944dd406e5cab2d719e657eace8ada98486231472.js"></script>
-    <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github-2682871eafdca76aa810dac6b2433150e4f9a5810fd29306c5149b29ef81cc31.js"></script>
+    <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-85e46509f591dce7595dbac97bce19eea295d412207fa9f8dd5bfdf02086961e.js"></script>
+    <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github-af22ca95d09e0937c9d9e7f23513c4ac3a77fbde6ceab69348667b928b55a67c.js"></script>
     
     
     

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -82,6 +82,15 @@ const CSS_IMPORT = regex`
   ${captureQuotedWord}
 `;
 
+const HTML_IMPORT = regex`
+  ^\s*
+  <link
+  \s
+  rel="import"
+  \s
+  href=${captureQuotedWord}>
+`;
+
 export {
   REQUIRE,
   IMPORT,
@@ -94,5 +103,6 @@ export {
   RUST_CRATE,
   PYTHON_IMPORT,
   CSS_IMPORT,
+  HTML_IMPORT,
   go,
 };

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -196,6 +196,14 @@ const fixtures = {
       '@import url(foo)',
     ],
   },
+  HTML_IMPORT: {
+    valid: [
+      '<link rel="import" href="foo">',
+    ],
+    invalid: [
+      '<link href="foo">',
+    ],
+  },
 };
 
 const goFixtures = {


### PR DESCRIPTION
Adding HTML import was an easy thing to do. The tricky part is to agree on which file extension we would like to support.

@tunnckoCore was providing the following

- highlight-text-html-basic // => .html, .html
- highlight-text-html-twig
- highlight-text-html-slim
- highlight-text-html-vue
- highlight-text-html-js // => ejs, and probably others
- highlight-text-html-handlebars // => hbs, handlebars, htmlbars
- highlight-text-html-erb
- highlight-text-jade // => jade, pug

what else do we need to add?

[Demo page](https://github.com/Polymer/polymer-analyzer/blob/b438736929167351a212d11a023c1c8849cdcad9/src/test/static/diamond/a.html)