### PR TITLE
Fetch and display release highlight

### DIFF
--- a/lib/gh-interface.js
+++ b/lib/gh-interface.js
@@ -8,24 +8,13 @@ export function showTooltip($target, msg) {
   $target.attr('aria-label', msg);
 }
 
-function getUserName() {
-  const el = window.document.querySelector('.header .css-truncate-target');
-  if (el && el.textContent.length) {
-    return ` ${el.textContent}`;
-  }
-  return '';
-}
-
-export function showNotification() {
-  const username = getUserName();
-
+export function showNotification({ description, version, url }) {
   const html = `<div class="flash flash-full">
     <div class="container">
       <button class="flash-close js-flash-close" type="button" aria-label="Dismiss this message">
         <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"></path></svg>
       </button>
-      <strong>Hello${username},</strong><br>
-      A new version of the OctoLinker extension has been released! — <a href="https://github.com/OctoLinker/browser-extension/releases" target="_blank">Read more</a>
+      New in OctoLinker ${version}: <b>${description}</b> – <a href="${url}" target="_blank">Release Notes</a>
     </div>
   </div>`;
 

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -15,6 +15,15 @@ export default function () {
   storage.set('version', pkgVersion);
 
   if (installedVersion && installedVersion !== pkgVersion) {
-    showNotification();
+    fetch('https://api.github.com/repos/octolinker/browser-extension/releases/latest')
+      .then(response => response.json())
+      .then(json => ({
+        description: json.body.split('\n')[0],
+        url: json.html_url,
+        version: json.tag_name.replace('v', ''),
+      }))
+      .then(({ description, url, version }) => {
+        showNotification({ description, url, version });
+      });
   }
 }

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -3,7 +3,7 @@ import * as storage from './options/storage.js';
 
 const pkgVersion = require('../package.json').version.split('.').slice(0, -1).join('.');
 
-export default function () {
+export default async function () {
   const showUpdateNotification = storage.get('showUpdateNotification');
 
   if (!showUpdateNotification) {
@@ -15,15 +15,11 @@ export default function () {
   storage.set('version', pkgVersion);
 
   if (installedVersion && installedVersion !== pkgVersion) {
-    fetch('https://api.github.com/repos/octolinker/browser-extension/releases/latest')
-      .then(response => response.json())
-      .then(json => ({
-        description: json.body.split('\n')[0],
-        url: json.html_url,
-        version: json.tag_name.replace('v', ''),
-      }))
-      .then(({ description, url, version }) => {
-        showNotification({ description, url, version });
-      });
+    const response = await fetch('https://api.github.com/repos/octolinker/browser-extension/releases/latest');
+    const json = await response.json();
+    const description = json.body.split('\n')[0];
+    const url = json.html_url;
+    const version = json.tag_name.replace('v', '');
+    showNotification({ description, url, version });
   }
 }


### PR DESCRIPTION
I thought it would be helpful to display the release highlight in the notification, so I created this PR.

<img width="610" alt="screen shot 2017-03-18 at 18 28 14" src="https://cloud.githubusercontent.com/assets/1393946/24074464/9183ae84-0c09-11e7-878d-4e9948941827.png">

The first release notes line defines the highlight and will be displayed in the notification.