### PR TITLE
Add partial support for sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ OctoLinker is the easiest and best way to navigate between files and projects on
 ### CSS
 - `@import`
 
+### Sass
+- `@import`
+
 ### HTML
 - `<link rel="import" href="...">`
 
@@ -125,7 +128,7 @@ Show your support to our open source project. Your donation will help us to cove
 
 - [Buy OctoLinker stickers](https://www.stickermule.com/marketplace/16611-the-official-logo)
 - [Donate with PayPal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=WSXA9GCDRMX7W)
-- [Become a backer or sponsor](https://opencollective.com/octolinker) 
+- [Become a backer or sponsor](https://opencollective.com/octolinker)
 
 # Legal and License
 

--- a/lib/pattern-preset.js
+++ b/lib/pattern-preset.js
@@ -100,6 +100,14 @@ export const presets = {
     ],
   },
 
+  sass: {
+    pathSubstrings: ['.scss', '.sass'],
+    githubClasses: [
+      'type-sass',
+      'highlight-source-sass',
+    ],
+  },
+
   html: {
     pathSubstrings: [
       '.html',

--- a/lib/plugins/sass.js
+++ b/lib/plugins/sass.js
@@ -1,0 +1,31 @@
+import { join } from 'path';
+import pathParse from 'path-parse';
+import { CSS_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
+import insertLink from '../insert-link';
+import preset from '../pattern-preset';
+import relativeFile from '../resolver/relative-file.js';
+
+export default class Sass {
+
+  static resolve({ path, target }) {
+    const { dir, name } = pathParse(target);
+    const prefixedTarget = join(dir, `_${name}`);
+
+    return [
+      relativeFile({ path, target: `${prefixedTarget}.scss` }),
+      relativeFile({ path, target: `${prefixedTarget}.sass` }),
+    ];
+  }
+
+  getPattern() {
+    return preset('sass');
+  }
+
+  parseBlob(blob) {
+    insertLink(blob.el, CSS_IMPORT, {
+      pluginName: this.constructor.name,
+      target: '$1',
+      path: blob.path,
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "github-url-from-username-repo": "^1.0.2",
     "giturl": "^1.0.0",
     "jquery": "^3.1.1",
+    "path-parse": "^1.0.5",
     "pop-zip": "^1.0.0",
     "querystring": "^0.2.0",
     "semver": "^5.3.0",

--- a/packages/blob-reader/fixtures/github.com/issue/code.html
+++ b/packages/blob-reader/fixtures/github.com/issue/code.html
@@ -11,11 +11,11 @@
 
 
 
-  <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/frameworks-19e26a1cefb5f1e92203a9468134dbf46b5a5308aeeeee09c96b32fec8c8b044.css" media="all" rel="stylesheet" />
-  <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github-a97f6b98170262f1be5dd5b84d3fb788f1bb65b269c11417026fe763d5eeb63b.css" media="all" rel="stylesheet" />
+  <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/frameworks-c4ea0a21580a57091fc76df379ba40e19a614ee3bdca871a3a8a2b38d181c65d.css" media="all" rel="stylesheet" />
+  <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github-a20b0761ae9a52b4ed0d75922904eb8ffb5934a855914ec141ff3b2140a18b9a.css" media="all" rel="stylesheet" />
   
   
-  <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/site-1da8b9f73abeb68e6a54d0f514085224fe9e7325fd664eacacb38bebe10b9eab.css" media="all" rel="stylesheet" />
+  <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/site-b29e324b8fafaead965049ef224818ef0dccc7384b5cfcad56a56a89c33a9438.css" media="all" rel="stylesheet" />
   
 
   <meta name="viewport" content="width=device-width">
@@ -49,7 +49,7 @@ package.json
   
   <meta name="pjax-timeout" content="1000">
   
-  <meta name="request-id" content="EA52:3E1A:2054DC:3375AF:58BDEC47" data-pjax-transient>
+  <meta name="request-id" content="D15A:0C43:2627860:3EA759E:58CE50E3" data-pjax-transient>
   
 
   <meta name="selected-link" value="repo_issues" data-pjax-transient>
@@ -58,7 +58,7 @@ package.json
 <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
     <meta name="google-analytics" content="UA-3769691-2">
 
-<meta content="collector.githubapp.com" name="octolytics-host" /><meta content="github" name="octolytics-app-id" /><meta content="https://collector.githubapp.com/github-external/browser_event" name="octolytics-event-url" /><meta content="EA52:3E1A:2054DC:3375AF:58BDEC47" name="octolytics-dimension-request_id" />
+<meta content="collector.githubapp.com" name="octolytics-host" /><meta content="github" name="octolytics-app-id" /><meta content="https://collector.githubapp.com/github-external/browser_event" name="octolytics-event-url" /><meta content="D15A:0C43:2627860:3EA759E:58CE50E3" name="octolytics-dimension-request_id" />
 <meta content="/&lt;user-name&gt;/&lt;repo-name&gt;/issues/show" data-pjax-transient="true" name="analytics-location" />
 
 
@@ -67,17 +67,18 @@ package.json
   <meta class="js-ga-set" name="dimension1" content="Logged Out">
 
 
-
+  
+  
       <meta name="hostname" content="github.com">
   <meta name="user-login" content="">
 
       <meta name="expected-hostname" content="github.com">
-    <meta name="js-proxy-site-detection-payload" content="NWU5YzgxYmU1MzAxZjc3YWRmNjY3NjA3ZDIwZWNjMzA2MjY5MjZlNGEyNWE0ZDFiNTY0ZjlmYmZmYWM1MWY0M3x7InJlbW90ZV9hZGRyZXNzIjoiMTA5LjE5Mi43NS41MyIsInJlcXVlc3RfaWQiOiJFQTUyOjNFMUE6MjA1NERDOjMzNzVBRjo1OEJERUM0NyIsInRpbWVzdGFtcCI6MTQ4ODg0MTc5OSwiaG9zdCI6ImdpdGh1Yi5jb20ifQ==">
+    <meta name="js-proxy-site-detection-payload" content="MTM4YzVjMWNkNjJkN2YxNzk1YjhjZWI1MzcwNjU0NGNmZDM4ZjMxYTE0OTY5NDc1ZDVjNzI1YzdhZWM1ZTIzZnx7InJlbW90ZV9hZGRyZXNzIjoiMTA5LjE5Mi43NS41MyIsInJlcXVlc3RfaWQiOiJEMTVBOjBDNDM6MjYyNzg2MDozRUE3NTlFOjU4Q0U1MEUzIiwidGltZXN0YW1wIjoxNDg5OTE2MTMyLCJob3N0IjoiZ2l0aHViLmNvbSJ9">
 
 
-  <meta name="html-safe-nonce" content="94beeb4bb1626580d1abbfccd0ec5e838c12bd18">
+  <meta name="html-safe-nonce" content="22325f993de0bd0f8ea37b6f073c2d95b0c585ae">
 
-  <meta http-equiv="x-pjax-version" content="6f7dd5e8045db8184cd083c6d969fed2">
+  <meta http-equiv="x-pjax-version" content="74a3d86e6b4050c0e213539f879855ae">
   
 
     
@@ -85,7 +86,7 @@ package.json
   <meta name="go-import" content="github.com/OctoLinker/testrepo git https://github.com/OctoLinker/testrepo.git">
 
   <meta content="10505593" name="octolytics-dimension-user_id" /><meta content="OctoLinker" name="octolytics-dimension-user_login" /><meta content="45358638" name="octolytics-dimension-repository_id" /><meta content="OctoLinker/testrepo" name="octolytics-dimension-repository_nwo" /><meta content="true" name="octolytics-dimension-repository_public" /><meta content="false" name="octolytics-dimension-repository_is_fork" /><meta content="45358638" name="octolytics-dimension-repository_network_root_id" /><meta content="OctoLinker/testrepo" name="octolytics-dimension-repository_network_root_nwo" />
-  <link href="https://github.com/OctoLinker/testrepo/commits/master.atom" rel="alternate" title="Recent Commits to testrepo:master" type="application/atom+xml">
+      <link href="https://github.com/OctoLinker/testrepo/commits/master.atom" rel="alternate" title="Recent Commits to testrepo:master" type="application/atom+xml">
 
 
 
@@ -103,7 +104,7 @@ package.json
 
   </head>
 
-  <body class="logged-out env-production vis-public">
+  <body class="logged-out env-production">
     
 
   <div class="position-relative js-header-wrapper ">
@@ -128,10 +129,10 @@ package.json
 
     <div class="site-header-menu">
       <nav class="site-header-nav">
-          <a href="/features" class="js-selected-navigation-item nav-item" data-ga-click="Header, click, Nav menu - item:features" data-selected-links="/features /features">
-            Features
-</a>          <a href="/explore" class="js-selected-navigation-item nav-item" data-ga-click="Header, click, Nav menu - item:explore" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship /showcases /explore">
-            Explore
+        <a href="/features" class="js-selected-navigation-item nav-item" data-ga-click="Header, click, Nav menu - item:features" data-selected-links="/features /features">
+          Features
+</a>        <a href="/explore" class="js-selected-navigation-item nav-item" data-ga-click="Header, click, Nav menu - item:explore" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship /showcases /explore">
+          Explore
 </a>        <a href="/pricing" class="js-selected-navigation-item nav-item" data-ga-click="Header, click, Nav menu - item:pricing" data-selected-links="/pricing /pricing">
           Pricing
 </a>      </nav>
@@ -175,17 +176,15 @@ package.json
   <div role="main">
       <div itemscope itemtype="http://schema.org/SoftwareSourceCode">
     <div id="js-repo-pjax-container" data-pjax-container>
-      
+        
 
 
 
 <div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav">
   <div class="container repohead-details-container">
 
-    
 
-<ul class="pagehead-actions">
-
+    <ul class="pagehead-actions">
   <li>
       <a href="/login?return_to=%2FOctoLinker%2Ftestrepo"
     class="btn btn-sm btn-with-count tooltipped tooltipped-n"
@@ -319,7 +318,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
   <div
     id="partial-discussion-header"
     class="gh-header js-details-container Details js-socket-channel js-updatable-content issue"
-    data-channel="tenant:1:issue:185246647"
+    data-channel="issue:185246647"
     data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Ftitle">
 
   <div class="gh-header-show ">
@@ -357,11 +356,11 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
       <div class="discussion-sidebar">
         <div id="partial-discussion-sidebar"
   class="js-socket-channel js-updatable-content"
-  data-channel="tenant:1:issue:185246647"
+  data-channel="issue:185246647"
   data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Fsidebar">
 
   <div class="discussion-sidebar-item sidebar-assignee js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Fassignees" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="Cc8nkt9N/MtqNc9ZCHFwgXjU7Po23rlC5nxcabdcd2riTq8Knp97Yd+wM/GtSnRFSWwAtWlatVZa5g/l5VnZug==" /></div>
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Fassignees" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="v43KFZGQ+n5kOsKFe/txNVwH+AZS7TdBQHlE996l0Ti7VU09K6NQ/P3o3qAybTSpf1olfDQX6aatT/9E2sb3JQ==" /></div>
     
   <h3 class="discussion-sidebar-heading">
     Assignees
@@ -375,7 +374,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 </form></div>
 
   <div class="discussion-sidebar-item sidebar-labels js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Flabels" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="QYUY1PnxpMCjIF/fHQcjK+eaTb9IISP8n8vzNV90c+qqBJBMuCMjahalo3e4PCfv1iKh8BelL+gjUaC5DXHdOg==" /></div>
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2?partial=issues%2Fsidebar%2Fshow%2Flabels" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="XA5aSFZBeim8pWKSSvS5mcpZDa/RRUtnuIz2VWC9R5pY1t1g7HLQqyV3frcDYvwF6QTQ1be/lYBVuk3mZN5hhw==" /></div>
       
   <h3 class="discussion-sidebar-heading">
     Labels
@@ -389,7 +388,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 </form></div>
 
   <div class="discussion-sidebar-item js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/projects/issues/2" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="6ZrOO53AXzq1TSH7w0eTU6pSxZuujPK/IlgW1MCYJ96ajAkfhKEln1VEm6u/e3+nKuz+eu9ZtEb4zMWlgABMDg==" /></div>
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/projects/issues/2" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="nS8DY+CBmZid0uE3h/ltAdr1LOVzlDtDKRXDQsc5ssnWmUXCMvjrng8/xCsm/RO1HhwcS9Apm5v3tKd19Rw0bQ==" /></div>
     
   <h3 class="discussion-sidebar-heading">
     Projects
@@ -403,7 +402,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 </form></div>
 
   <div class="discussion-sidebar-item sidebar-milestone js-discussion-sidebar-item">
-  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2/set_milestone?partial=issues%2Fsidebar%2Fshow%2Fmilestone" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="Qv7Uazpt/XL6+k0BwGfz01aeSyQCKfwEafnk0+FSBfsLxuSsNY2mUceOGf14kZef8fpX1x3va8IWz98dQMQPHQ==" /></div>
+  <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/issues/2/set_milestone?partial=issues%2Fsidebar%2Fshow%2Fmilestone" class="js-issue-sidebar-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="_method" type="hidden" value="put" /><input name="authenticity_token" type="hidden" value="rrpc4CbV9IPorc0GSWhqgy3T0Hu+glJrli3959PhgiVaOMNBQG5WWXEHJV8aoTeQqVV3Qc7RGkKy7LWaueq9bA==" /></div>
     
   <h3 class="discussion-sidebar-heading">
     Milestone
@@ -436,7 +435,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
       <div class="discussion-timeline js-quote-selection-container ">
 
-        <div class="js-discussion js-socket-channel" data-channel="tenant:1:marked-as-read:issue:185246647">
+        <div class="js-discussion js-socket-channel" data-channel="marked-as-read:issue:185246647">
           
 
   <div class="timeline-comment-wrapper js-comment-container">
@@ -475,7 +474,7 @@ span.labelstyle-ffffff, .linked-labelstyle-ffffff {  background-color: #ffffff !
 
       &#8226;
       <span class="timestamp timestamp-edited tooltipped tooltipped-n"
-            aria-label="stefanbuck edited this issue less than a minute ago">
+            aria-label="stefanbuck edited this issue 12 days ago">
         edited
       </span>
   </div>
@@ -546,14 +545,14 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 
 
 
-<!-- Rendered timeline since 2017-03-06 15:09:33 -->
+<!-- Rendered timeline since 2017-03-06 15:14:39 -->
 <div id="partial-timeline-marker"
       class="js-timeline-marker js-socket-channel js-updatable-content"
-      data-channel="tenant:1:issue:185246647"
-      data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Ftimeline_marker&amp;since=1488841773"
-      data-last-modified="Mon, 06 Mar 2017 23:09:33 GMT">
+      data-channel="issue:185246647"
+      data-url="/OctoLinker/testrepo/issues/2/show_partial?partial=issues%2Ftimeline_marker&amp;since=1488842079"
+      data-last-modified="Mon, 06 Mar 2017 23:14:39 GMT">
 
-    <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/notifications/mark?ids=176302197" class="d-none js-timeline-marker-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="8M0+HuOgC/fuKkylHyPGsh4lHn3flunH6sYMpT/BSdQqTpMYNMSe5D55f47EfoKJXa9pBGChD2lCTf4Y1u3ePg==" /></div>
+    <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/OctoLinker/testrepo/notifications/mark?ids=176302197" class="d-none js-timeline-marker-form" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="Aa9hGB76ThtHGer44W6QEYkizfBSzB9M9n+OuKIHSq6puED4hj9bx7V/dfOaVTHb1yOTLK+kREdIjskCjqhleQ==" /></div>
 </form></div>
 
 
@@ -582,6 +581,8 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
 </div>
 
 
+
+
     </div>
   </div>
 
@@ -603,7 +604,7 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
       <svg aria-hidden="true" class="octicon octicon-mark-github" height="24" version="1.1" viewBox="0 0 16 16" width="24"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
 </a>
     <ul class="site-footer-links">
-      <li>&copy; 2017 <span title="0.12153s from github-fe165-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
+      <li>&copy; 2017 <span title="0.11422s from github-fe134-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
         <li><a href="https://github.com/site/terms" data-ga-click="Footer, go to terms, text:terms">Terms</a></li>
         <li><a href="https://github.com/site/privacy" data-ga-click="Footer, go to privacy, text:privacy">Privacy</a></li>
         <li><a href="https://github.com/security" data-ga-click="Footer, go to security, text:security">Security</a></li>
@@ -626,9 +627,9 @@ Bundle <span class="pl-s"><span class="pl-pds">"</span>http://github.com/thinca/
   </div>
 
 
-    <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/compat-8e19569aacd39e737a14c8515582825f3c90d1794c0e5539f9b525b8eb8b5a8e.js"></script>
-    <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-85e46509f591dce7595dbac97bce19eea295d412207fa9f8dd5bfdf02086961e.js"></script>
-    <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github-af22ca95d09e0937c9d9e7f23513c4ac3a77fbde6ceab69348667b928b55a67c.js"></script>
+    <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/compat-70e3b0d6db8a244e38107bc491aeebe3143cc21a339e00bfc5d446bac07d7b51.js"></script>
+    <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-f595606838fa8089d82001c6b4da7f6ba33f31dde48065e00390143b90dab642.js"></script>
+    <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github-d6af8e24ce0e91bd50a4bcf222948a6f1068acbfa091b8dedc688ceccf197754.js"></script>
     
     
     

--- a/test/plugins/sass.test.js
+++ b/test/plugins/sass.test.js
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import Sass from '../../lib/plugins/sass';
+
+describe('Sass', () => {
+  const path = '/octo/dog.scss';
+
+  it('resolves link when target does not have a file extension', () => {
+    assert.deepEqual(
+      Sass.resolve({ path, target: 'foo' }),
+      [
+        '{BASE_URL}/octo/_foo.scss',
+        '{BASE_URL}/octo/_foo.sass',
+      ],
+    );
+  });
+
+  it('resolves link when target has a file extension', () => {
+    assert.deepEqual(
+      Sass.resolve({ path, target: 'foo.scss' }),
+      [
+        '{BASE_URL}/octo/_foo.scss',
+        '{BASE_URL}/octo/_foo.sass',
+      ],
+    );
+  });
+});


### PR DESCRIPTION
This PR adds support for relative sass imports. It doesn't take [includePaths](https://github.com/sass/node-sass#includepaths) into account. 

[Demo](https://github.com/twbs/bootstrap/blob/v4-dev/scss/bootstrap-grid.scss)

**TODO**
- [x] Add tests
- [x] Document feature 