### PR TITLE
Add partial support for less

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ OctoLinker is the easiest and best way to navigate between files and projects on
 ### Sass
 - `@import`
 
+### less
+- `@import`
+
 ### HTML
 - `<link rel="import" href="...">`
 

--- a/lib/pattern-preset.js
+++ b/lib/pattern-preset.js
@@ -108,6 +108,14 @@ export const presets = {
     ],
   },
 
+  less: {
+    pathSubstrings: ['.less'],
+    githubClasses: [
+      'type-less',
+      'highlight-source-css-less',
+    ],
+  },
+
   html: {
     pathSubstrings: [
       '.html',

--- a/lib/plugins/less.js
+++ b/lib/plugins/less.js
@@ -1,0 +1,25 @@
+import { CSS_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
+import insertLink from '../insert-link';
+import preset from '../pattern-preset';
+import relativeFile from '../resolver/relative-file.js';
+
+export default class Less {
+
+  static resolve({ path, target }) {
+    return [
+      relativeFile({ path, target }),
+    ];
+  }
+
+  getPattern() {
+    return preset('less');
+  }
+
+  parseBlob(blob) {
+    insertLink(blob.el, CSS_IMPORT, {
+      pluginName: this.constructor.name,
+      target: '$1',
+      path: blob.path,
+    });
+  }
+}

--- a/test/plugins/less.test.js
+++ b/test/plugins/less.test.js
@@ -1,0 +1,15 @@
+import assert from 'assert';
+import Less from '../../lib/plugins/less';
+
+describe('Less', () => {
+  const path = '/octo/dog.less';
+
+  it('resolves links', () => {
+    assert.deepEqual(
+      Less.resolve({ path, target: 'foo.less' }),
+      [
+        '{BASE_URL}/octo/foo.less',
+      ],
+    );
+  });
+});


### PR DESCRIPTION
This PR adds support for relative less imports. It doesn't take [includePaths](http://lesscss.org/usage/) into account. 

[Demo](https://github.com/less/less-docs/blob/master/styles/index.less)

![less](https://cloud.githubusercontent.com/assets/1393946/24168917/3b88b8ce-0e7c-11e7-82a7-301b33140f70.gif)
