### PR TITLE
helper-grammar-regex-collection: dedupe exports

### DIFF
--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -1,5 +1,6 @@
-import go from './go.js';
 import regex from './regex';
+
+export { default as go } from './go.js';
 
 const captureQuotedWord = regex`
   ['"]            # beginning quote
@@ -10,45 +11,45 @@ const captureQuotedWord = regex`
 const importMembers = regex`[\r\n\s\w{},*\$]*`;
 const from = regex`\s from \s`;
 
-const REQUIRE = regex`
+export const REQUIRE = regex`
   ( require(\.resolve)? | import )
   ( \s | \( ) \s*
   ${captureQuotedWord}
 `;
 
-const IMPORT = regex`
+export const IMPORT = regex`
   import \s ${importMembers}
   ${from}?
   ${captureQuotedWord}
 `;
 
-const EXPORT = regex`
+export const EXPORT = regex`
   export \s ${importMembers}
   ${from}
   ${captureQuotedWord}
 `;
 
-const GEM = regex`
+export const GEM = regex`
   gem \s ${captureQuotedWord}
 `;
 
-const HOMEBREW = regex`
+export const HOMEBREW = regex`
   (depends_on|conflicts_with)
   ( \s cask: | \s formula: )?
   \s
   ${captureQuotedWord}
 `;
 
-const TYPESCRIPT_REFERENCE = regex`
+export const TYPESCRIPT_REFERENCE = regex`
   \/{3} \s?
   <reference \s path=${captureQuotedWord}
 `;
 
-const DOCKER_FROM = regex`
+export const DOCKER_FROM = regex`
   FROM \s (?<$1>[^\n]*)
 `;
 
-const VIM_PLUGIN = regex`
+export const VIM_PLUGIN = regex`
   (
     (
       (Neo)?
@@ -61,25 +62,25 @@ const VIM_PLUGIN = regex`
   ${captureQuotedWord}
 `;
 
-const RUST_CRATE = regex`
+export const RUST_CRATE = regex`
   \b (extern \s crate | use)
   \s
   (?<$1>[^:;\s]+)
 `;
 
-const PYTHON_IMPORT = regex`
+export const PYTHON_IMPORT = regex`
   ^\s*
   (import|from)
   \s
   (?<$1>[^\s]*)
 `;
 
-const HASKELL_IMPORT = regex`
+export const HASKELL_IMPORT = regex`
   ((^|\s)import\s+(qualified\s)?)
   (?<$1> [A-Z][\w.]+)
 `;
 
-const CSS_IMPORT = regex`
+export const CSS_IMPORT = regex`
   ^\s*
   @import
   \s
@@ -87,7 +88,7 @@ const CSS_IMPORT = regex`
   ${captureQuotedWord}
 `;
 
-const HTML_IMPORT = regex`
+export const HTML_IMPORT = regex`
   ^\s*
   <link
   \s
@@ -95,20 +96,3 @@ const HTML_IMPORT = regex`
   \s
   href=${captureQuotedWord}>
 `;
-
-export {
-  REQUIRE,
-  IMPORT,
-  EXPORT,
-  GEM,
-  HOMEBREW,
-  TYPESCRIPT_REFERENCE,
-  DOCKER_FROM,
-  VIM_PLUGIN,
-  RUST_CRATE,
-  PYTHON_IMPORT,
-  CSS_IMPORT,
-  HTML_IMPORT,
-  go,
-  HASKELL_IMPORT,
-};


### PR DESCRIPTION
This way, we don't have to have that big export statement at the
bottom of the file, with all of the variable names repeated.