### PR TITLE
Less: support `@import` keywords

### DIFF
--- a/lib/plugins/less.js
+++ b/lib/plugins/less.js
@@ -1,4 +1,4 @@
-import { CSS_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
+import { LESS_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
 import insertLink from '../insert-link';
 import preset from '../pattern-preset';
 import relativeFile from '../resolver/relative-file.js';
@@ -16,7 +16,7 @@ export default class Less {
   }
 
   parseBlob(blob) {
-    insertLink(blob.el, CSS_IMPORT, {
+    insertLink(blob.el, LESS_IMPORT, {
       pluginName: this.constructor.name,
       target: '$1',
       path: blob.path,

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -88,6 +88,15 @@ export const CSS_IMPORT = regex`
   ${captureQuotedWord}
 `;
 
+export const LESS_IMPORT = regex`
+  ^\s*
+  @import
+  \s
+  ( \([a-z, ]+\) \s+ )? # http://lesscss.org/features/#import-options
+  ((url|URL)\()?
+  ${captureQuotedWord}
+`;
+
 export const HTML_IMPORT = regex`
   ^\s*
   <link

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -258,6 +258,26 @@ const fixtures = {
       '@import url(foo)',
     ],
   },
+  LESS_IMPORT: {
+    valid: [
+      '@import (less) "foo";',
+      '@import (optional, reference) "foo";',
+      // below copied from CSS_IMPORT
+      '@import \'foo\'',
+      '@import "foo"',
+      '@import "foo" bar',
+      '@import URL("foo")',
+      '@import url("foo")',
+      '@import url("foo") bar',
+      // above copied from CSS_IMPORT
+    ],
+    invalid: [
+      // below copied from CSS_IMPORT
+      '@import foo',
+      '@import url(foo)',
+      // above copied from CSS_IMPORT
+    ],
+  },
   HTML_IMPORT: {
     valid: [
       '<link rel="import" href="foo">',


### PR DESCRIPTION
This follows up on commit 8736eac (#322)

See http://lesscss.org/features/#import-options

Demo page: https://github.com/less/less-docs/blob/315c5b3633d2ff2b94054574cfdf57132aa95eed/styles/index.less#L13