### PR TITLE
Fallback to fuzzy search

### DIFF
--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -52,6 +52,12 @@ function getResolverUrls(dataAttr) {
       return null;
     }
 
+    if (typeof url === 'function') {
+      return {
+        func: url,
+      };
+    }
+
     if (typeof url === 'object') {
       return {
         url: url.url.replace('{BASE_URL}', BASE_URL),

--- a/lib/plugins/haskell.js
+++ b/lib/plugins/haskell.js
@@ -1,6 +1,7 @@
 import { HASKELL_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
 import insertLink from '../insert-link';
 import preset from '../pattern-preset';
+import githubSearch from '../resolver/github-search.js';
 
 export default class Haskell {
   static resolve({ path, target }) {
@@ -10,6 +11,7 @@ export default class Haskell {
       `{BASE_URL}/${user}/${repo}/blob/master/src/${filePath}.hs`,
       `{BASE_URL}/${user}/${repo}/blob/master/lib/${filePath}.hs`,
       `{BASE_URL}/${user}/${repo}/blob/master/${filePath}.hs`,
+      githubSearch({ path, target: `${filePath}.hs` }),
       `https://hackage.haskell.org/package/base/docs/${target.replace(/\./g, '-')}.html`,
     ];
   }

--- a/lib/plugins/less.js
+++ b/lib/plugins/less.js
@@ -2,12 +2,14 @@ import { LESS_IMPORT } from '../../packages/helper-grammar-regex-collection/inde
 import insertLink from '../insert-link';
 import preset from '../pattern-preset';
 import relativeFile from '../resolver/relative-file.js';
+import githubSearch from '../resolver/github-search.js';
 
 export default class Less {
 
   static resolve({ path, target }) {
     return [
       relativeFile({ path, target }),
+      githubSearch({ path, target }),
     ];
   }
 

--- a/lib/plugins/sass.js
+++ b/lib/plugins/sass.js
@@ -4,6 +4,7 @@ import { CSS_IMPORT } from '../../packages/helper-grammar-regex-collection/index
 import insertLink from '../insert-link';
 import preset from '../pattern-preset';
 import relativeFile from '../resolver/relative-file.js';
+import githubSearch from '../resolver/github-search.js';
 
 export default class Sass {
 
@@ -14,6 +15,8 @@ export default class Sass {
     return [
       relativeFile({ path, target: `${prefixedTarget}.scss` }),
       relativeFile({ path, target: `${prefixedTarget}.sass` }),
+      githubSearch({ path, target: `${prefixedTarget}.scss` }),
+      githubSearch({ path, target: `${prefixedTarget}.sass` }),
     ];
   }
 

--- a/lib/resolver/github-search.js
+++ b/lib/resolver/github-search.js
@@ -1,0 +1,20 @@
+import { extname } from 'path';
+
+export default function ({ path, target }) {
+  const [, user, repo] = path.split('/');
+  const extension = extname(target);
+
+  let params = `q=${target}+in:path+filename:${target}+repo:${user}/${repo}`;
+  if (extension) {
+    params += `+extension:${extension}`;
+  }
+
+  const url = `https://api.github.com/search/code?${params}`;
+
+  return async function githubSearch() {
+    const response = await fetch(url);
+    const json = await response.json();
+
+    return json.items[0].html_url;
+  };
+}

--- a/lib/utils/fetch.js
+++ b/lib/utils/fetch.js
@@ -1,8 +1,14 @@
 import $ from 'jquery';
 
 export default async (urls) => {
-  for (const { url, method = 'HEAD' } of urls) {
+  for (const { url, func, method = 'HEAD' } of urls) {
     try {
+      if (func) {
+        return {
+          url: await func(), // eslint-disable-line no-await-in-loop
+        };
+      }
+
       // Normally, you wouldn't use `await` inside of a loop.
       // However, we explicity want to do this sequentially.
       // See http://eslint.org/docs/rules/no-await-in-loop

--- a/test/plugins/haskell.test.js
+++ b/test/plugins/haskell.test.js
@@ -1,16 +1,19 @@
 import assert from 'assert';
 import Haskell from '../../lib/plugins/haskell';
+import githubSearch from '../../lib/resolver/github-search.js';
 
 describe('haskell', () => {
   const path = '/user/repo/blob/d6/lib/plugins/javascript.js';
+  const target = 'Foo.Bar';
 
   it('resolves links', () => {
     assert.deepEqual(
-      Haskell.resolve({ path, target: 'Foo.Bar' }),
+      Haskell.resolve({ path, target }),
       [
         '{BASE_URL}/user/repo/blob/master/src/Foo/Bar.hs',
         '{BASE_URL}/user/repo/blob/master/lib/Foo/Bar.hs',
         '{BASE_URL}/user/repo/blob/master/Foo/Bar.hs',
+        githubSearch({ path, target }).toString(),
         'https://hackage.haskell.org/package/base/docs/Foo-Bar.html',
       ],
     );

--- a/test/plugins/less.test.js
+++ b/test/plugins/less.test.js
@@ -1,14 +1,17 @@
 import assert from 'assert';
 import Less from '../../lib/plugins/less';
+import githubSearch from '../../lib/resolver/github-search.js';
 
 describe('Less', () => {
   const path = '/octo/dog.less';
+  const target = 'foo.less';
 
   it('resolves links', () => {
     assert.deepEqual(
-      Less.resolve({ path, target: 'foo.less' }),
+      Less.resolve({ path, target }),
       [
         '{BASE_URL}/octo/foo.less',
+        githubSearch({ path, target }).toString(),
       ],
     );
   });

--- a/test/plugins/sass.test.js
+++ b/test/plugins/sass.test.js
@@ -1,15 +1,19 @@
 import assert from 'assert';
 import Sass from '../../lib/plugins/sass';
+import githubSearch from '../../lib/resolver/github-search.js';
 
 describe('Sass', () => {
   const path = '/octo/dog.scss';
+  const target = 'foo';
 
   it('resolves link when target does not have a file extension', () => {
     assert.deepEqual(
-      Sass.resolve({ path, target: 'foo' }),
+      Sass.resolve({ path, target }),
       [
         '{BASE_URL}/octo/_foo.scss',
         '{BASE_URL}/octo/_foo.sass',
+        githubSearch({ path, target }).toString(),
+        githubSearch({ path, target }).toString(),
       ],
     );
   });
@@ -20,6 +24,8 @@ describe('Sass', () => {
       [
         '{BASE_URL}/octo/_foo.scss',
         '{BASE_URL}/octo/_foo.sass',
+        githubSearch({ path, target }).toString(),
+        githubSearch({ path, target }).toString(),
       ],
     );
   });

--- a/test/resolver/github-search.test.js
+++ b/test/resolver/github-search.test.js
@@ -1,0 +1,45 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import githubSearch from '../../lib/resolver/github-search.js';
+
+describe('github-search', () => {
+  const sandbox = sinon.sandbox.create();
+  const fetchStub = sinon.stub(window, 'fetch');
+
+  const path = '/octo/foo.txt';
+  const target = 'bar.txt';
+
+  afterEach(() => {
+    fetchStub.reset();
+    sandbox.reset();
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  it('returns a function', () => {
+    assert.deepEqual(
+      typeof githubSearch({ path, target }),
+      'function',
+    );
+  });
+
+  it('calls the github search api', () => {
+    githubSearch({ path, target })();
+
+    assert.deepEqual(
+      fetchStub.args[0][0],
+      'https://api.github.com/search/code?q=bar.txt+in:path+filename:bar.txt+repo:octo/foo.txt+extension:.txt',
+    );
+  });
+
+  it('does not append query param "extension" when target does not have a file extension', () => {
+    githubSearch({ path, target: 'bar' })();
+
+    assert.deepEqual(
+      fetchStub.args[0][0],
+      'https://api.github.com/search/code?q=bar+in:path+filename:bar+repo:octo/foo.txt',
+    );
+  });
+});


### PR DESCRIPTION
Today, I tried to implement support for [less includePaths](http://lesscss.org/usage/) and [sass includePaths](https://github.com/sass/node-sass#includepaths). As expect this is really tricky to implement and maybe even impossible. There is no single point of truth where this property is defined. It could be everywhere. Of course we could search  in common places like in `gruntfile.js` or `gulpfile.js` file, but even that isn't entirely accurate. If the path isn't stored a string we're screwed.

Luckily, an idea came to my head and thought giving it a try. Why not using GitHub`s [search API](https://developer.github.com/v3/search/). I know that this isn't very accurate either, but at least it works in many (hopefully in almost every) case. 

I need a bit more time to think about it. I opened the PR to share the basic idea with you. What do you think @josephfrazier

[This](https://github.com/less/less-docs/blob/master/styles/index.less#L12) import wasn't working before. 