### PR TITLE
Ruby require_relative support

### DIFF
--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -12,7 +12,7 @@ const importMembers = regex`[\r\n\s\w{},*\$]*`;
 const from = regex`\s from \s`;
 
 export const REQUIRE = regex`
-  ( require(\.resolve)? | import )
+  ( require(\.resolve)? | import | require_relative )
   \s* ( \s | \( ) \s*
   ${captureQuotedWord}
 `;

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -68,6 +68,7 @@ const fixtures = {
       ['foo = require("./foo")bar = require("./bar")', ['./foo', './bar']],
       ['const foo = require("./foo")bar = require("./bar")', ['./foo', './bar']],
       'require "foo"',
+      'require_relative "foo"',
       // require.resolve
       'require.resolve "foo"',
       'require.resolve("foo")',
@@ -103,6 +104,10 @@ const fixtures = {
       'require"foo"',
       'require (foo)',
       'require("fo o")',
+      'require_relative(foo)',
+      'require_relative"foo"',
+      'require_relative (foo)',
+      'require_relative("fo o")',
       // require.resolve
       'require.resolve(foo)',
       'require.resolve"foo"',


### PR DESCRIPTION
This follows up on issue #326. `require_relative` links are clickable with this PR but do not always work. For example, the first link on <a href="https://github.com/MatthewDG/ormellow/blob/master/lib/sql_object.rb">this page</a> tries to resolve a path to a page dedicated to a Ruby gem, but the other two require_relative links work fine. On many other pages such as <a href="https://github.com/rails/rails/blob/master/actioncable/test/subscription_adapter/redis_test.rb">this one</a>, the links just throw a 404 error in the console.