### PR TITLE
Support *requirements.txt files

### DIFF
--- a/lib/pattern-preset.js
+++ b/lib/pattern-preset.js
@@ -1,10 +1,10 @@
 export const presets = {
 
   JavaScript: {
-    pathSubstrings: [
-      '.js',
-      '.jsx',
-      '.es6',
+    pathPatterns: [
+      '.js$',
+      '.jsx$',
+      '.es6$',
     ],
     githubClasses: [
       'type-javascript',
@@ -14,7 +14,7 @@ export const presets = {
   },
 
   CoffeeScript: {
-    pathSubstrings: ['.coffee'],
+    pathPatterns: ['.coffee$'],
     githubClasses: [
       'type-coffeescript',
       'highlight-source-coffee',
@@ -22,7 +22,7 @@ export const presets = {
   },
 
   TypeScript: {
-    pathSubstrings: ['.ts'],
+    pathPatterns: ['.ts$'],
     githubClasses: [
       'type-typescript',
       'highlight-source-ts',
@@ -30,7 +30,7 @@ export const presets = {
   },
 
   Ruby: {
-    pathSubstrings: ['.rb'],
+    pathPatterns: ['.rb$'],
     githubClasses: [
       'type-ruby',
       'highlight-source-ruby',
@@ -38,7 +38,7 @@ export const presets = {
   },
 
   Docker: {
-    pathSubstrings: ['Dockerfile'],
+    pathPatterns: ['/Dockerfile$'],
     githubClasses: [
       'type-dockerfile',
       'highlight-source-dockerfile',
@@ -46,14 +46,14 @@ export const presets = {
   },
 
   Vim: {
-    pathSubstrings: [
-      '.vimrc',
-      '.gvimrc',
-      '.vim',
+    pathPatterns: [
+      '.vimrc$',
+      '.gvimrc$',
+      '.vim$',
       // Sometimes there's no leading dot in .vimrc and .gvimrc, for example:
       // https://github.com/gmarik/vimfiles/blob/1f4f26d42f54443f1158e0009746a56b9a28b053/vimrc#L136
-      'vimrc',
-      'gvimrc',
+      '/vimrc$',
+      '/gvimrc$',
     ],
     githubClasses: [
       'type-viml',
@@ -62,7 +62,7 @@ export const presets = {
   },
 
   Rust: {
-    pathSubstrings: ['.rs'],
+    pathPatterns: ['.rs$'],
     githubClasses: [
       'type-rust',
       'highlight-source-rust',
@@ -70,7 +70,7 @@ export const presets = {
   },
 
   Python: {
-    pathSubstrings: ['.py'],
+    pathPatterns: ['.py$'],
     githubClasses: [
       'type-python',
       'highlight-source-python',
@@ -78,12 +78,12 @@ export const presets = {
   },
 
   RequirementsTxt: {
-    pathSubstrings: ['requirements.txt'],
+    pathPatterns: ['/requirements.txt$'],
     githubClasses: [],
   },
 
   Go: {
-    pathSubstrings: ['.go'],
+    pathPatterns: ['.go$'],
     githubClasses: [
       'type-go',
       'highlight-source-go',
@@ -91,14 +91,14 @@ export const presets = {
   },
 
   Haskell: {
-    pathSubstrings: ['.hs'],
+    pathPatterns: ['.hs$'],
     githubClasses: [
       'type-haskell',
     ],
   },
 
   css: {
-    pathSubstrings: ['.css'],
+    pathPatterns: ['.css$'],
     githubClasses: [
       'type-css',
       'highlight-source-css',
@@ -106,7 +106,7 @@ export const presets = {
   },
 
   sass: {
-    pathSubstrings: ['.scss', '.sass'],
+    pathPatterns: ['.scss$', '.sass$'],
     githubClasses: [
       'type-sass',
       'highlight-source-sass',
@@ -114,7 +114,7 @@ export const presets = {
   },
 
   less: {
-    pathSubstrings: ['.less'],
+    pathPatterns: ['.less$'],
     githubClasses: [
       'type-less',
       'highlight-source-css-less',
@@ -122,9 +122,9 @@ export const presets = {
   },
 
   html: {
-    pathSubstrings: [
-      '.html',
-      '.htm',
+    pathPatterns: [
+      '.html$',
+      '.htm$',
     ],
     githubClasses: [
       'type-html',
@@ -138,7 +138,7 @@ export default function (presetName, siblingPresetName) {
   }
 
   return {
-    pathSubstrings: presets[presetName].pathSubstrings.concat(presets[siblingPresetName].pathSubstrings),
+    pathPatterns: presets[presetName].pathPatterns.concat(presets[siblingPresetName].pathPatterns),
     githubClasses: presets[presetName].githubClasses.concat(presets[siblingPresetName].githubClasses),
   };
 }

--- a/lib/pattern-preset.js
+++ b/lib/pattern-preset.js
@@ -78,7 +78,7 @@ export const presets = {
   },
 
   RequirementsTxt: {
-    pathPatterns: ['/requirements.txt$'],
+    pathPatterns: ['requirements.txt$'],
     githubClasses: [],
   },
 

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -1,4 +1,3 @@
-import { extname, basename } from 'path';
 import { flattenAndCompact } from './utils/array';
 
 function updatePluginsForKey(lookup, plugin, key) {
@@ -23,8 +22,8 @@ function buildPluginCache(plugins) {
   plugins.forEach((PluginClass) => {
     const plugin = new PluginClass();
 
-    (plugin.getPattern().pathSubstrings || plugin.getPattern()).forEach((pattern) => {
-      updatePluginsForKey(lookup, plugin, pattern);
+    (plugin.getPattern().pathPatterns || plugin.getPattern()).forEach((pattern) => {
+      updatePluginsForKey(lookup, plugin, RegExp(pattern));
     });
 
     if (!plugin.getPattern().githubClasses) {
@@ -39,12 +38,14 @@ function buildPluginCache(plugins) {
   return lookup;
 }
 
-function getPluginsForExt(plugins, filepath) {
-  return plugins.get(extname(filepath));
-}
-
-function getPluginsForFilename(plugins, filepath) {
-  return plugins.get(basename(filepath));
+function getPluginsForPath(plugins, filepath) {
+  let results = [];
+  for (const [key, value] of plugins) {
+    if (key instanceof RegExp && key.test(filepath)) {
+      results = results.concat(value);
+    }
+  }
+  return results;
 }
 
 function getPluginsForGithubClasses(plugins, classList) {
@@ -75,8 +76,7 @@ export default class {
 
   get(filepath, classList) {
     const filepathPlugins = flattenAndCompact([
-      getPluginsForExt(this._plugins, filepath),
-      getPluginsForFilename(this._plugins, filepath),
+      getPluginsForPath(this._plugins, filepath),
     ]);
     if (filepathPlugins.length) {
       return filepathPlugins;

--- a/lib/plugins/bower-manifest.js
+++ b/lib/plugins/bower-manifest.js
@@ -47,7 +47,7 @@ export default class BowerManifest {
   }
 
   getPattern() {
-    return ['bower.json'];
+    return ['/bower.json$'];
   }
 
   parseBlob(blob) {

--- a/lib/plugins/composer-manifest.js
+++ b/lib/plugins/composer-manifest.js
@@ -23,7 +23,7 @@ export default class Composer {
   }
 
   getPattern() {
-    return ['composer.json'];
+    return ['/composer.json$'];
   }
 
   parseBlob(blob) {

--- a/lib/plugins/dot-net-core.js
+++ b/lib/plugins/dot-net-core.js
@@ -20,7 +20,7 @@ export default class DotNetCore {
   }
 
   getPattern() {
-    return ['project.json'];
+    return ['/project.json$'];
   }
 
   parseBlob(blob) {

--- a/lib/plugins/gemfile-manifest.js
+++ b/lib/plugins/gemfile-manifest.js
@@ -12,7 +12,7 @@ export default class Rubygems {
   }
 
   getPattern() {
-    return ['Gemfile'];
+    return ['/Gemfile$'];
   }
 
   parseBlob(blob) {

--- a/lib/plugins/npm-manifest.js
+++ b/lib/plugins/npm-manifest.js
@@ -47,7 +47,7 @@ export default class NpmManifest {
   }
 
   getPattern() {
-    return ['package.json'];
+    return ['/package.json$'];
   }
 
   parseBlob(blob) {

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -258,7 +258,7 @@ const fixtures = {
       ['flake8', ['flake8']],
     ],
     invalid: [
-      '# doc-opt==0.6.2',
+      '-r requirements.txt',
     ],
   },
   CSS_IMPORT: {

--- a/test/pattern-preset.test.js
+++ b/test/pattern-preset.test.js
@@ -28,10 +28,10 @@ describe('pattern-preset', () => {
 
   it('returns patterns for the given preset', () => {
     assert.deepEqual(patternPresets('JavaScript'), {
-      pathSubstrings: [
-        '.js',
-        '.jsx',
-        '.es6',
+      pathPatterns: [
+        '.js$',
+        '.jsx$',
+        '.es6$',
       ],
       githubClasses: [
         'type-javascript',
@@ -43,7 +43,7 @@ describe('pattern-preset', () => {
 
   it('merges pattern for the given presets', () => {
     assert.deepEqual(patternPresets('JavaScript', 'CoffeeScript'), {
-      pathSubstrings: ['.js', '.jsx', '.es6', '.coffee'],
+      pathPatterns: ['.js$', '.jsx$', '.es6$', '.coffee$'],
       githubClasses: [
         'type-javascript',
         'type-jsx',


### PR DESCRIPTION
Following up on https://github.com/OctoLinker/browser-extension/pull/332#issuecomment-289582089,
this change allows filenames like [dev-requirements.txt] to be linked.

Making this possible required some changes to the file path matching
mechanism, which can be found in commit 468d46a. After that, it was
straightforward to match the additional *requirements.txt patterns (commit 3e94b62),
then add a test for the linking regex (commit a595a85).

Since this pull request has both the filepath refactoring and an
additional feature, I think it should be merged using GitHub's "Rebase and merge"
option, to preserve the meaning of the individual commits.

[dev-requirements.txt]: https://github.com/alanhamlett/pip-update-requirements/blob/c8d64c8c865be48f1654052a546f68f37e718ff9/dev-requirements.txt