### PR TITLE
package.json plugin: link `module` and `jsnext:main` fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ OctoLinker is the easiest and best way to navigate between files and projects on
 
 ### package.json (npm)
 - `main`
+- `module` and `jsnext:main`
 - `bin`
 - `browser`
 - `dependencies`

--- a/lib/plugins/npm-manifest.js
+++ b/lib/plugins/npm-manifest.js
@@ -57,6 +57,8 @@ export default class NpmManifest {
       '$.peerDependencies': linkDependency,
       '$.optionalDependencies': linkDependency,
       '$.main': linkFile,
+      '$.module': linkFile,
+      '$.jsnext:main': linkFile,
       '$.bin': linkFile,
       '$.browser': linkFile,
       '$.typings': linkFile,


### PR DESCRIPTION
Test page: https://github.com/northbrookjs/northbrook/blob/84a31d4f54db97b7448216b9bb04fc4671e28092/src/plugins/exec/__test__/a/package.json#L5-L6

Fixes https://github.com/OctoLinker/browser-extension/issues/235