### PR TITLE
webpack: Use absolute output path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin'); // eslint-disable-line
 
 module.exports = {
@@ -8,7 +9,7 @@ module.exports = {
   },
   devtool: 'source-map',
   output: {
-    path: 'dist',
+    path: path.resolve(__dirname, 'dist'),
     filename: '[name].js',
   },
   plugins: [


### PR DESCRIPTION
This will avoid the following error once webpack is updated:

    Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
     - configuration.output.path: The provided value "dist" is not an absolute path!

See https://github.com/josephfrazier/octopermalinker/commit/6e0e4fedc9613026b196d99bcb0a371f0eb0b287