### PR TITLE
Extract common parseBlob() from plugins

### DIFF
--- a/lib/octo-linker.js
+++ b/lib/octo-linker.js
@@ -3,6 +3,7 @@ import notification from './notification';
 import BlobReader from '../packages/blob-reader';
 import clickHandler from './click-handler';
 import Plugins from './plugin-manager.js';
+import insertLink from './insert-link';
 import debugMode from './debug-mode.js';
 import loadPlugins from './load-plugins';
 import * as storage from './options/storage.js';
@@ -32,7 +33,17 @@ function run(self) {
     }
 
     plugins.forEach((plugin) => {
-      plugin.parseBlob(blob);
+      if (plugin.parseBlob) {
+        plugin.parseBlob(blob);
+      } else if (plugin.constructor.getLinkRegexes) {
+        plugin.constructor.getLinkRegexes(blob).forEach((regex) => {
+          insertLink(blob.el, regex, {
+            pluginName: plugin.constructor.name,
+            target: '$1',
+            path: blob.path,
+          });
+        });
+      }
     });
   });
 }

--- a/lib/octo-linker.js
+++ b/lib/octo-linker.js
@@ -36,7 +36,7 @@ function run(self) {
       if (plugin.parseBlob) {
         plugin.parseBlob(blob);
       } else if (plugin.constructor.getLinkRegexes) {
-        plugin.constructor.getLinkRegexes(blob).forEach((regex) => {
+        [].concat(plugin.constructor.getLinkRegexes(blob)).forEach((regex) => {
           insertLink(blob.el, regex, {
             pluginName: plugin.constructor.name,
             target: '$1',

--- a/lib/plugins/css.js
+++ b/lib/plugins/css.js
@@ -20,6 +20,6 @@ export default class CSS {
   }
 
   static getLinkRegexes() {
-    return [CSS_IMPORT];
+    return CSS_IMPORT;
   }
 }

--- a/lib/plugins/css.js
+++ b/lib/plugins/css.js
@@ -1,5 +1,4 @@
 import { CSS_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 import relativeFile from '../resolver/relative-file.js';
 
 export default class CSS {
@@ -20,11 +19,7 @@ export default class CSS {
     };
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, CSS_IMPORT, {
-      pluginName: this.constructor.name,
-      target: '$1',
-      path: blob.path,
-    });
+  static getLinkRegexes() {
+    return [CSS_IMPORT];
   }
 }

--- a/lib/plugins/docker.js
+++ b/lib/plugins/docker.js
@@ -26,6 +26,6 @@ export default class Docker {
   }
 
   static getLinkRegexes() {
-    return [DOCKER_FROM];
+    return DOCKER_FROM;
   }
 }

--- a/lib/plugins/docker.js
+++ b/lib/plugins/docker.js
@@ -3,11 +3,11 @@ import insertLink from '../insert-link';
 
 export default class Docker {
 
-  static resolve({ image }) {
+  static resolve({ target }) {
     let isOffical = true;
-    const imageName = image.split(':')[0];
+    const imageName = target.split(':')[0];
 
-    if (image.includes('/')) {
+    if (target.includes('/')) {
       isOffical = false;
     }
 
@@ -29,7 +29,7 @@ export default class Docker {
   parseBlob(blob) {
     insertLink(blob.el, DOCKER_FROM, {
       pluginName: this.constructor.name,
-      image: '$1',
+      target: '$1',
     });
   }
 }

--- a/lib/plugins/docker.js
+++ b/lib/plugins/docker.js
@@ -1,5 +1,4 @@
 import { DOCKER_FROM } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 
 export default class Docker {
 
@@ -26,10 +25,7 @@ export default class Docker {
     };
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, DOCKER_FROM, {
-      pluginName: this.constructor.name,
-      target: '$1',
-    });
+  static getLinkRegexes() {
+    return [DOCKER_FROM];
   }
 }

--- a/lib/plugins/gemfile-manifest.js
+++ b/lib/plugins/gemfile-manifest.js
@@ -18,6 +18,6 @@ export default class Rubygems {
   }
 
   static getLinkRegexes() {
-    return [GEM];
+    return GEM;
   }
 }

--- a/lib/plugins/gemfile-manifest.js
+++ b/lib/plugins/gemfile-manifest.js
@@ -1,5 +1,4 @@
 import { GEM } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 import liveResolverQuery from '../resolver/live-resolver-query.js';
 
 export default class Rubygems {
@@ -18,10 +17,7 @@ export default class Rubygems {
     };
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, GEM, {
-      pluginName: this.constructor.name,
-      target: '$1',
-    });
+  static getLinkRegexes() {
+    return [GEM];
   }
 }

--- a/lib/plugins/go.js
+++ b/lib/plugins/go.js
@@ -1,6 +1,5 @@
 import { join, dirname } from 'path';
 import { go } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 
 function goFile({ path, target }) {
   const list = [];
@@ -63,13 +62,7 @@ export default class Go {
     };
   }
 
-  parseBlob(blob) {
-    go(blob.toString()).forEach((val) => {
-      insertLink(blob.el, val, {
-        pluginName: this.constructor.name,
-        target: '$1',
-        path: blob.path,
-      });
-    });
+  static getLinkRegexes(blob) {
+    return go(blob.toString());
   }
 }

--- a/lib/plugins/haskell.js
+++ b/lib/plugins/haskell.js
@@ -24,6 +24,6 @@ export default class Haskell {
   }
 
   static getLinkRegexes() {
-    return [HASKELL_IMPORT];
+    return HASKELL_IMPORT;
   }
 }

--- a/lib/plugins/haskell.js
+++ b/lib/plugins/haskell.js
@@ -1,5 +1,4 @@
 import { HASKELL_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 import githubSearch from '../resolver/github-search.js';
 
 export default class Haskell {
@@ -24,11 +23,7 @@ export default class Haskell {
     };
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, HASKELL_IMPORT, {
-      pluginName: this.constructor.name,
-      target: '$1',
-      path: blob.path,
-    });
+  static getLinkRegexes() {
+    return [HASKELL_IMPORT];
   }
 }

--- a/lib/plugins/homebrew-manifest.js
+++ b/lib/plugins/homebrew-manifest.js
@@ -1,5 +1,4 @@
 import { HOMEBREW } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 import Ruby from './ruby';
 import relativeFile from '../resolver/relative-file.js';
 
@@ -26,11 +25,7 @@ export default class Homebrew {
     return Ruby.getPattern();
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, HOMEBREW, {
-      pluginName: this.constructor.name,
-      path: blob.path,
-      target: '$1.rb',
-    });
+  static getLinkRegexes() {
+    return [HOMEBREW];
   }
 }

--- a/lib/plugins/homebrew-manifest.js
+++ b/lib/plugins/homebrew-manifest.js
@@ -26,6 +26,6 @@ export default class Homebrew {
   }
 
   static getLinkRegexes() {
-    return [HOMEBREW];
+    return HOMEBREW;
   }
 }

--- a/lib/plugins/html.js
+++ b/lib/plugins/html.js
@@ -22,6 +22,6 @@ export default class HTML {
   }
 
   static getLinkRegexes() {
-    return [HTML_IMPORT];
+    return HTML_IMPORT;
   }
 }

--- a/lib/plugins/html.js
+++ b/lib/plugins/html.js
@@ -1,5 +1,4 @@
 import { HTML_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 import relativeFile from '../resolver/relative-file.js';
 
 export default class HTML {
@@ -22,11 +21,7 @@ export default class HTML {
     };
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, HTML_IMPORT, {
-      pluginName: this.constructor.name,
-      target: '$1',
-      path: blob.path,
-    });
+  static getLinkRegexes() {
+    return [HTML_IMPORT];
   }
 }

--- a/lib/plugins/javascript.js
+++ b/lib/plugins/javascript.js
@@ -1,7 +1,6 @@
 import { join, dirname, extname } from 'path';
 import concatMap from 'concat-map';
 import { REQUIRE, IMPORT, EXPORT } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 import builtinsDocs from '../utils/builtins-docs.js';
 import liveResolverQuery from '../resolver/live-resolver-query.js';
 
@@ -95,13 +94,7 @@ export default class JavaScript {
     };
   }
 
-  parseBlob(blob) {
-    [REQUIRE, IMPORT, EXPORT].forEach((regex) => {
-      insertLink(blob.el, regex, {
-        pluginName: this.constructor.name,
-        target: '$1',
-        path: blob.path,
-      });
-    });
+  static getLinkRegexes() {
+    return [REQUIRE, IMPORT, EXPORT];
   }
 }

--- a/lib/plugins/less.js
+++ b/lib/plugins/less.js
@@ -1,5 +1,4 @@
 import { LESS_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 import relativeFile from '../resolver/relative-file.js';
 import githubSearch from '../resolver/github-search.js';
 
@@ -22,11 +21,7 @@ export default class Less {
     };
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, LESS_IMPORT, {
-      pluginName: this.constructor.name,
-      target: '$1',
-      path: blob.path,
-    });
+  static getLinkRegexes() {
+    return [LESS_IMPORT];
   }
 }

--- a/lib/plugins/less.js
+++ b/lib/plugins/less.js
@@ -22,6 +22,6 @@ export default class Less {
   }
 
   static getLinkRegexes() {
-    return [LESS_IMPORT];
+    return LESS_IMPORT;
   }
 }

--- a/lib/plugins/python.js
+++ b/lib/plugins/python.js
@@ -43,6 +43,6 @@ export default class Python {
   }
 
   static getLinkRegexes() {
-    return [PYTHON_IMPORT];
+    return PYTHON_IMPORT;
   }
 }

--- a/lib/plugins/python.js
+++ b/lib/plugins/python.js
@@ -1,5 +1,4 @@
 import { PYTHON_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 import liveResolverQuery from '../resolver/live-resolver-query.js';
 import relativeFile from '../resolver/relative-file.js';
 
@@ -43,11 +42,7 @@ export default class Python {
     };
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, PYTHON_IMPORT, {
-      pluginName: this.constructor.name,
-      target: '$1',
-      path: blob.path,
-    });
+  static getLinkRegexes() {
+    return [PYTHON_IMPORT];
   }
 }

--- a/lib/plugins/requirements-txt.js
+++ b/lib/plugins/requirements-txt.js
@@ -20,6 +20,6 @@ export default class RequirementsTxt {
   }
 
   static getLinkRegexes() {
-    return [REQUIREMENTS_TXT];
+    return REQUIREMENTS_TXT;
   }
 }

--- a/lib/plugins/requirements-txt.js
+++ b/lib/plugins/requirements-txt.js
@@ -1,5 +1,4 @@
 import { REQUIREMENTS_TXT } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 import liveResolverQuery from '../resolver/live-resolver-query.js';
 
 export default class RequirementsTxt {
@@ -20,11 +19,7 @@ export default class RequirementsTxt {
     };
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, REQUIREMENTS_TXT, {
-      pluginName: this.constructor.name,
-      target: '$1',
-      path: blob.path,
-    });
+  static getLinkRegexes() {
+    return [REQUIREMENTS_TXT];
   }
 }

--- a/lib/plugins/ruby.js
+++ b/lib/plugins/ruby.js
@@ -1,6 +1,5 @@
 import { join } from 'path';
 import { REQUIRE } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 import liveResolverQuery from '../resolver/live-resolver-query.js';
 
 export default class Ruby {
@@ -31,11 +30,7 @@ export default class Ruby {
     };
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, REQUIRE, {
-      pluginName: this.constructor.name,
-      target: '$1',
-      path: blob.path,
-    });
+  static getLinkRegexes() {
+    return [REQUIRE];
   }
 }

--- a/lib/plugins/ruby.js
+++ b/lib/plugins/ruby.js
@@ -31,6 +31,6 @@ export default class Ruby {
   }
 
   static getLinkRegexes() {
-    return [REQUIRE];
+    return REQUIRE;
   }
 }

--- a/lib/plugins/rust.js
+++ b/lib/plugins/rust.js
@@ -18,6 +18,6 @@ export default class Rust {
   }
 
   static getLinkRegexes() {
-    return [RUST_CRATE];
+    return RUST_CRATE;
   }
 }

--- a/lib/plugins/rust.js
+++ b/lib/plugins/rust.js
@@ -1,5 +1,4 @@
 import { RUST_CRATE } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 import liveResolverQuery from '../resolver/live-resolver-query.js';
 
 export default class Rust {
@@ -18,10 +17,7 @@ export default class Rust {
     };
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, RUST_CRATE, {
-      pluginName: this.constructor.name,
-      target: '$1',
-    });
+  static getLinkRegexes() {
+    return [RUST_CRATE];
   }
 }

--- a/lib/plugins/sass.js
+++ b/lib/plugins/sass.js
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import pathParse from 'path-parse';
 import { CSS_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 import relativeFile from '../resolver/relative-file.js';
 import githubSearch from '../resolver/github-search.js';
 
@@ -29,11 +28,7 @@ export default class Sass {
     };
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, CSS_IMPORT, {
-      pluginName: this.constructor.name,
-      target: '$1',
-      path: blob.path,
-    });
+  static getLinkRegexes() {
+    return [CSS_IMPORT];
   }
 }

--- a/lib/plugins/sass.js
+++ b/lib/plugins/sass.js
@@ -29,6 +29,6 @@ export default class Sass {
   }
 
   static getLinkRegexes() {
-    return [CSS_IMPORT];
+    return CSS_IMPORT;
   }
 }

--- a/lib/plugins/typescript.js
+++ b/lib/plugins/typescript.js
@@ -1,6 +1,5 @@
 import JavaScript from './javascript';
 import { TYPESCRIPT_REFERENCE } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 
 export default class TypeScript extends JavaScript {
   static getPattern() {
@@ -13,13 +12,7 @@ export default class TypeScript extends JavaScript {
     };
   }
 
-  parseBlob(blob) {
-    super.parseBlob(blob);
-
-    insertLink(blob.el, TYPESCRIPT_REFERENCE, {
-      pluginName: this.constructor.name,
-      target: '$1',
-      path: blob.path,
-    });
+  static getLinkRegexes(blob) {
+    return JavaScript.getLinkRegexes(blob).concat(TYPESCRIPT_REFERENCE);
   }
 }

--- a/lib/plugins/vim.js
+++ b/lib/plugins/vim.js
@@ -1,7 +1,6 @@
 import ghShorthand from 'github-url-from-username-repo';
 import giturl from 'giturl';
 import { VIM_PLUGIN } from '../../packages/helper-grammar-regex-collection/index.js';
-import insertLink from '../insert-link';
 
 export default class Vim {
 
@@ -40,10 +39,7 @@ export default class Vim {
     };
   }
 
-  parseBlob(blob) {
-    insertLink(blob.el, VIM_PLUGIN, {
-      pluginName: this.constructor.name,
-      shorthand: '$1',
-    });
+  static getLinkRegexes() {
+    return [VIM_PLUGIN];
   }
 }

--- a/lib/plugins/vim.js
+++ b/lib/plugins/vim.js
@@ -40,6 +40,6 @@ export default class Vim {
   }
 
   static getLinkRegexes() {
-    return [VIM_PLUGIN];
+    return VIM_PLUGIN;
   }
 }

--- a/test/plugins/docker.test.js
+++ b/test/plugins/docker.test.js
@@ -4,35 +4,35 @@ import dockerImage from '../../lib/plugins/docker';
 describe('docker-image', () => {
   it('resolves foo to https://hub.docker.com/_/foo', () => {
     assert.deepEqual(
-      dockerImage.resolve({ image: 'foo' }),
+      dockerImage.resolve({ target: 'foo' }),
       ['https://hub.docker.com/_/foo'],
     );
   });
 
   it('resolves foo:1.2.3 to https://hub.docker.com/_/foo', () => {
     assert.deepEqual(
-      dockerImage.resolve({ image: 'foo:1.2.3' }),
+      dockerImage.resolve({ target: 'foo:1.2.3' }),
       ['https://hub.docker.com/_/foo'],
     );
   });
 
   it('resolves foo:1.2.3-alpha to https://hub.docker.com/_/foo', () => {
     assert.deepEqual(
-      dockerImage.resolve({ image: 'foo:1.2.3-alpha' }),
+      dockerImage.resolve({ target: 'foo:1.2.3-alpha' }),
       ['https://hub.docker.com/_/foo'],
     );
   });
 
   it('resolves foo/bar to https://hub.docker.com/r/foo/bar', () => {
     assert.deepEqual(
-      dockerImage.resolve({ image: 'foo/bar' }),
+      dockerImage.resolve({ target: 'foo/bar' }),
       ['https://hub.docker.com/r/foo/bar'],
     );
   });
 
   it('resolves foo/bar:1.2.3 to https://hub.docker.com/r/foo/bar', () => {
     assert.deepEqual(
-      dockerImage.resolve({ image: 'foo/bar:1.2.3' }),
+      dockerImage.resolve({ target: 'foo/bar:1.2.3' }),
       ['https://hub.docker.com/r/foo/bar'],
     );
   });


### PR DESCRIPTION
Since so many of the plugins have the same `parseBlob` implementation
(just with a different set of regexes), let's make it so that the
plugins can just specify the regexes to use with `insertLink`