### PR TITLE
javascript: Fix link to Node's `constants` module

### DIFF
--- a/lib/utils/builtins-docs.js
+++ b/lib/utils/builtins-docs.js
@@ -9,4 +9,6 @@ const docs = builtins.reduce((result, builtin) => {
   return result;
 }, {});
 
+docs.constants = 'https://github.com/nodejs/node/blob/master/lib/constants.js';
+
 export default docs;


### PR DESCRIPTION
This module is internal, but is nevertheless used in some places.
Here's one example:
https://github.com/isaacs/node-touch/blob/f73938c01bd10fe70fae5af3f37fc8c6162e9852/touch.js#L2