### PR TITLE
Make plugins regular objects instead of classes

### DIFF
--- a/lib/octo-linker.js
+++ b/lib/octo-linker.js
@@ -35,10 +35,10 @@ function run(self) {
     plugins.forEach((plugin) => {
       if (plugin.parseBlob) {
         plugin.parseBlob(blob);
-      } else if (plugin.constructor.getLinkRegexes) {
-        [].concat(plugin.constructor.getLinkRegexes(blob)).forEach((regex) => {
+      } else if (plugin.getLinkRegexes) {
+        [].concat(plugin.getLinkRegexes(blob)).forEach((regex) => {
           insertLink(blob.el, regex, {
-            pluginName: plugin.constructor.name,
+            pluginName: plugin.name,
             target: '$1',
             path: blob.path,
           });

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -19,18 +19,16 @@ function updatePluginsForKey(lookup, plugin, key) {
 function buildPluginCache(plugins) {
   const lookup = new Map();
 
-  plugins.forEach((PluginClass) => {
-    const plugin = new PluginClass();
-
-    PluginClass.getPattern().pathPatterns.forEach((pattern) => {
+  plugins.forEach((plugin) => {
+    plugin.getPattern().pathPatterns.forEach((pattern) => {
       updatePluginsForKey(lookup, plugin, RegExp(pattern));
     });
 
-    if (!PluginClass.getPattern().githubClasses) {
+    if (!plugin.getPattern().githubClasses) {
       return;
     }
 
-    PluginClass.getPattern().githubClasses.forEach((githubClass) => {
+    plugin.getPattern().githubClasses.forEach((githubClass) => {
       updatePluginsForKey(lookup, plugin, githubClass);
     });
   });
@@ -59,7 +57,7 @@ export default class {
   }
 
   getResolver(pluginName) {
-    const plugin = this._pluginsList.find(pluginClass => pluginClass.name === pluginName);
+    const plugin = this._pluginsList.find(({ name }) => name === pluginName);
 
     if (!plugin) {
       console.error(`Plugin ${pluginName} not found`);  // eslint-disable-line no-console

--- a/lib/plugins/bower-manifest.js
+++ b/lib/plugins/bower-manifest.js
@@ -29,9 +29,10 @@ function linkFile(blob, key, value) {
   });
 }
 
-export default class BowerManifest {
+export default {
+  name: 'BowerManifest',
 
-  static resolve({ target, path, type }) {
+  resolve({ target, path, type }) {
     if (type === 'file') {
       return javascriptFile({ target, path });
     }
@@ -44,14 +45,14 @@ export default class BowerManifest {
       gitUrl({ target }),
       githubShorthand({ target }),
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['/bower.json$'],
       githubClasses: [],
     };
-  }
+  },
 
   parseBlob(blob) {
     processJSON(blob, {
@@ -60,5 +61,5 @@ export default class BowerManifest {
       '$.resolutions': linkDependency,
       '$.main': linkFile,
     });
-  }
-}
+  },
+};

--- a/lib/plugins/composer-manifest.js
+++ b/lib/plugins/composer-manifest.js
@@ -16,18 +16,19 @@ function linkDependency(blob, key, value) {
   });
 }
 
-export default class Composer {
+export default {
+  name: 'Composer',
 
-  static resolve({ target }) {
+  resolve({ target }) {
     return liveResolverQuery({ type: 'composer', target });
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['/composer.json$'],
       githubClasses: [],
     };
-  }
+  },
 
   parseBlob(blob) {
     processJSON(blob, {
@@ -38,5 +39,5 @@ export default class Composer {
       '$.provide': linkDependency,
       '$.suggest': linkDependency,
     });
-  }
-}
+  },
+};

--- a/lib/plugins/css.js
+++ b/lib/plugins/css.js
@@ -1,15 +1,16 @@
 import { CSS_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
 import relativeFile from '../resolver/relative-file.js';
 
-export default class CSS {
+export default {
+  name: 'CSS',
 
-  static resolve({ target, path }) {
+  resolve({ target, path }) {
     return [
       relativeFile({ path, target }),
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['.css$'],
       githubClasses: [
@@ -17,9 +18,9 @@ export default class CSS {
         'highlight-source-css',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return CSS_IMPORT;
-  }
-}
+  },
+};

--- a/lib/plugins/docker.js
+++ b/lib/plugins/docker.js
@@ -1,8 +1,9 @@
 import { DOCKER_FROM } from '../../packages/helper-grammar-regex-collection/index.js';
 
-export default class Docker {
+export default {
+  name: 'Docker',
 
-  static resolve({ target }) {
+  resolve({ target }) {
     let isOffical = true;
     const imageName = target.split(':')[0];
 
@@ -13,9 +14,9 @@ export default class Docker {
     return [
       `https://hub.docker.com/${isOffical ? '_' : 'r'}/${imageName}`,
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['/Dockerfile$'],
       githubClasses: [
@@ -23,9 +24,9 @@ export default class Docker {
         'highlight-source-dockerfile',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return DOCKER_FROM;
-  }
-}
+  },
+};

--- a/lib/plugins/dot-net-core.js
+++ b/lib/plugins/dot-net-core.js
@@ -11,25 +11,26 @@ function linkDependency(blob, key, value) {
   });
 }
 
-export default class DotNetCore {
+export default {
+  name: 'DotNetCore',
 
-  static resolve({ target }) {
+  resolve({ target }) {
     return [
       `https://www.nuget.org/packages/${target}`,
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['/project.json$'],
       githubClasses: [],
     };
-  }
+  },
 
   parseBlob(blob) {
     processJSON(blob, {
       '$.dependencies': linkDependency,
       '$.tools': linkDependency,
     });
-  }
-}
+  },
+};

--- a/lib/plugins/gemfile-manifest.js
+++ b/lib/plugins/gemfile-manifest.js
@@ -1,23 +1,24 @@
 import { GEM } from '../../packages/helper-grammar-regex-collection/index.js';
 import liveResolverQuery from '../resolver/live-resolver-query.js';
 
-export default class Rubygems {
+export default {
+  name: 'Rubygems',
 
-  static resolve({ target }) {
+  resolve({ target }) {
     return liveResolverQuery({
       target: target.split('.')[0],
       type: 'rubygems',
     });
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['/Gemfile$'],
       githubClasses: [],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return GEM;
-  }
-}
+  },
+};

--- a/lib/plugins/go.js
+++ b/lib/plugins/go.js
@@ -33,9 +33,10 @@ function githubUrls(url) {
   ];
 }
 
-export default class Go {
+export default {
+  name: 'Go',
 
-  static resolve({ target, path }) {
+  resolve({ target, path }) {
     const isPath = !!target.match(/^\.\.?[\\|\/]?/);
 
     if (isPath) {
@@ -50,9 +51,9 @@ export default class Go {
       `https://${target}`,
       `https://golang.org/pkg/${target}`,
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['.go$'],
       githubClasses: [
@@ -60,9 +61,9 @@ export default class Go {
         'highlight-source-go',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes(blob) {
+  getLinkRegexes(blob) {
     return go(blob.toString());
-  }
-}
+  },
+};

--- a/lib/plugins/haskell.js
+++ b/lib/plugins/haskell.js
@@ -1,8 +1,10 @@
 import { HASKELL_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
 import githubSearch from '../resolver/github-search.js';
 
-export default class Haskell {
-  static resolve({ path, target }) {
+export default {
+  name: 'Haskell',
+
+  resolve({ path, target }) {
     const [, user, repo] = path.split('/');
     const filePath = target.replace(/\./g, '/');
     return [
@@ -12,18 +14,18 @@ export default class Haskell {
       githubSearch({ path, target: `${filePath}.hs` }),
       `https://hackage.haskell.org/package/base/docs/${target.replace(/\./g, '-')}.html`,
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['.hs$'],
       githubClasses: [
         'type-haskell',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return HASKELL_IMPORT;
-  }
-}
+  },
+};

--- a/lib/plugins/homebrew-manifest.js
+++ b/lib/plugins/homebrew-manifest.js
@@ -2,16 +2,17 @@ import { HOMEBREW } from '../../packages/helper-grammar-regex-collection/index.j
 import Ruby from './ruby';
 import relativeFile from '../resolver/relative-file.js';
 
-export default class Homebrew {
+export default {
+  name: 'Homebrew',
 
-  static resolve({ path, target }) {
+  resolve({ path, target }) {
     return [
       relativeFile({ path, target }),
       `https://github.com/Homebrew/homebrew-core/blob/master/Formula/${target}`,
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     // We could maybe be a little more specific here, but I doubt the
     // HOMEBREW pattern shows up in unrelated Ruby files. Note that we want to
     // match not only files in https://github.com/Homebrew/homebrew-core, but
@@ -23,9 +24,9 @@ export default class Homebrew {
     // * https://github.com/search?l=ruby&langOverride=&q=depends_on&repo=&start_value=1&type=Code
     // * https://github.com/search?l=ruby&langOverride=&q=conflicts_with&repo=&start_value=1&type=Code
     return Ruby.getPattern();
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return HOMEBREW;
-  }
-}
+  },
+};

--- a/lib/plugins/html.js
+++ b/lib/plugins/html.js
@@ -1,15 +1,16 @@
 import { HTML_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
 import relativeFile from '../resolver/relative-file.js';
 
-export default class HTML {
+export default {
+  name: 'HTML',
 
-  static resolve({ target, path }) {
+  resolve({ target, path }) {
     return [
       relativeFile({ path, target }),
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: [
         '.html$',
@@ -19,9 +20,9 @@ export default class HTML {
         'type-html',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return HTML_IMPORT;
-  }
-}
+  },
+};

--- a/lib/plugins/javascript.js
+++ b/lib/plugins/javascript.js
@@ -51,8 +51,10 @@ export function javascriptFile({ path, target }) {
   });
 }
 
-export default class JavaScript {
-  static resolve({ target, path }) {
+export default {
+  name: 'JavaScript',
+
+  resolve({ target, path }) {
     const isPath = !!target.match(/^\.\.?[\\|\/]?/);
     const isBuildIn = target in builtinsDocs;
 
@@ -72,9 +74,9 @@ export default class JavaScript {
       liveResolverQuery({ type: 'npm', target: topModuleName }),
       liveResolverQuery({ type: 'bower', target: topModuleName }),
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: [
         '.js$',
@@ -92,9 +94,9 @@ export default class JavaScript {
         'highlight-source-coffee',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return [REQUIRE, IMPORT, EXPORT];
-  }
-}
+  },
+};

--- a/lib/plugins/less.js
+++ b/lib/plugins/less.js
@@ -2,16 +2,17 @@ import { LESS_IMPORT } from '../../packages/helper-grammar-regex-collection/inde
 import relativeFile from '../resolver/relative-file.js';
 import githubSearch from '../resolver/github-search.js';
 
-export default class Less {
+export default {
+  name: 'Less',
 
-  static resolve({ path, target }) {
+  resolve({ path, target }) {
     return [
       relativeFile({ path, target }),
       githubSearch({ path, target }),
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['.less$'],
       githubClasses: [
@@ -19,9 +20,9 @@ export default class Less {
         'highlight-source-css-less',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return LESS_IMPORT;
-  }
-}
+  },
+};

--- a/lib/plugins/npm-manifest.js
+++ b/lib/plugins/npm-manifest.js
@@ -29,9 +29,10 @@ function linkFile(blob, key, value) {
   });
 }
 
-export default class NpmManifest {
+export default {
+  name: 'NpmManifest',
 
-  static resolve({ target, path, type }) {
+  resolve({ target, path, type }) {
     if (type === 'file') {
       return javascriptFile({ target, path });
     }
@@ -44,14 +45,14 @@ export default class NpmManifest {
       gitUrl({ target }),
       githubShorthand({ target }),
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['/package.json$'],
       githubClasses: [],
     };
-  }
+  },
 
   parseBlob(blob) {
     processJSON(blob, {
@@ -67,5 +68,5 @@ export default class NpmManifest {
       '$.typings': linkFile,
       '$.types': linkFile,
     });
-  }
-}
+  },
+};

--- a/lib/plugins/python.js
+++ b/lib/plugins/python.js
@@ -2,9 +2,10 @@ import { PYTHON_IMPORT } from '../../packages/helper-grammar-regex-collection/in
 import liveResolverQuery from '../resolver/live-resolver-query.js';
 import relativeFile from '../resolver/relative-file.js';
 
-export default class Python {
+export default {
+  name: 'Python',
 
-  static resolve({ path, target }) {
+  resolve({ path, target }) {
     const isLocalFile = target.startsWith('.') && target.length > 1;
     const isInit = target === '.';
     const apiDoc = `https://docs.python.org/3/library/${target}.html`;
@@ -30,9 +31,9 @@ export default class Python {
         type: 'pypi',
       }),
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['.py$'],
       githubClasses: [
@@ -40,9 +41,9 @@ export default class Python {
         'highlight-source-python',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return PYTHON_IMPORT;
-  }
-}
+  },
+};

--- a/lib/plugins/requirements-txt.js
+++ b/lib/plugins/requirements-txt.js
@@ -1,25 +1,26 @@
 import { REQUIREMENTS_TXT } from '../../packages/helper-grammar-regex-collection/index.js';
 import liveResolverQuery from '../resolver/live-resolver-query.js';
 
-export default class RequirementsTxt {
+export default {
+  name: 'RequirementsTxt',
 
-  static resolve({ target }) {
+  resolve({ target }) {
     return [
       liveResolverQuery({
         target,
         type: 'pypi',
       }),
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['requirements.txt$'],
       githubClasses: [],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return REQUIREMENTS_TXT;
-  }
-}
+  },
+};

--- a/lib/plugins/ruby.js
+++ b/lib/plugins/ruby.js
@@ -2,9 +2,10 @@ import { join } from 'path';
 import { REQUIRE } from '../../packages/helper-grammar-regex-collection/index.js';
 import liveResolverQuery from '../resolver/live-resolver-query.js';
 
-export default class Ruby {
+export default {
+  name: 'Ruby',
 
-  static resolve({ target, path }) {
+  resolve({ target, path }) {
     const isPath = !!target.match(/\//);
 
     // https://github.com/github/pages-gem/blob/master/lib/github-pages/dependencies.rb
@@ -18,9 +19,9 @@ export default class Ruby {
     return [
       liveResolverQuery({ type: 'rubygems', target }),
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['.rb$'],
       githubClasses: [
@@ -28,9 +29,9 @@ export default class Ruby {
         'highlight-source-ruby',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return REQUIRE;
-  }
-}
+  },
+};

--- a/lib/plugins/rust.js
+++ b/lib/plugins/rust.js
@@ -1,13 +1,14 @@
 import { RUST_CRATE } from '../../packages/helper-grammar-regex-collection/index.js';
 import liveResolverQuery from '../resolver/live-resolver-query.js';
 
-export default class Rust {
+export default {
+  name: 'Rust',
 
-  static resolve({ target }) {
+  resolve({ target }) {
     return liveResolverQuery({ type: 'crates', target });
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['.rs$'],
       githubClasses: [
@@ -15,9 +16,9 @@ export default class Rust {
         'highlight-source-rust',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return RUST_CRATE;
-  }
-}
+  },
+};

--- a/lib/plugins/sass.js
+++ b/lib/plugins/sass.js
@@ -4,9 +4,10 @@ import { CSS_IMPORT } from '../../packages/helper-grammar-regex-collection/index
 import relativeFile from '../resolver/relative-file.js';
 import githubSearch from '../resolver/github-search.js';
 
-export default class Sass {
+export default {
+  name: 'Sass',
 
-  static resolve({ path, target }) {
+  resolve({ path, target }) {
     const { dir, name } = pathParse(target);
     const prefixedTarget = join(dir, `_${name}`);
 
@@ -16,9 +17,9 @@ export default class Sass {
       githubSearch({ path, target: `${prefixedTarget}.scss` }),
       githubSearch({ path, target: `${prefixedTarget}.sass` }),
     ];
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: ['.scss$', '.sass$'],
       githubClasses: [
@@ -26,9 +27,9 @@ export default class Sass {
         'highlight-source-sass',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return CSS_IMPORT;
-  }
-}
+  },
+};

--- a/lib/plugins/typescript.js
+++ b/lib/plugins/typescript.js
@@ -1,8 +1,12 @@
 import JavaScript from './javascript';
 import { TYPESCRIPT_REFERENCE } from '../../packages/helper-grammar-regex-collection/index.js';
 
-export default class TypeScript extends JavaScript {
-  static getPattern() {
+export default {
+  name: 'TypeScript',
+
+  resolve: JavaScript.resolve,
+
+  getPattern() {
     return {
       pathPatterns: ['.ts$'],
       githubClasses: [
@@ -10,9 +14,9 @@ export default class TypeScript extends JavaScript {
         'highlight-source-ts',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes(blob) {
+  getLinkRegexes(blob) {
     return JavaScript.getLinkRegexes(blob).concat(TYPESCRIPT_REFERENCE);
-  }
-}
+  },
+};

--- a/lib/plugins/vim.js
+++ b/lib/plugins/vim.js
@@ -2,9 +2,10 @@ import ghShorthand from 'github-url-from-username-repo';
 import giturl from 'giturl';
 import { VIM_PLUGIN } from '../../packages/helper-grammar-regex-collection/index.js';
 
-export default class Vim {
+export default {
+  name: 'Vim',
 
-  static resolve({ shorthand }) {
+  resolve({ shorthand }) {
     // Logic adapted from https://github.com/VundleVim/Vundle.vim/blob/11fdc428fe741f4f6974624ad76ab7c2b503b73e/doc/vundle.txt#L196
     const components = shorthand.split('/');
 
@@ -19,9 +20,9 @@ export default class Vim {
     // Assume it's a URL otherwise. We can't link to git/ssh, so change to https
     // and hope it works.
     return giturl.parse(shorthand);
-  }
+  },
 
-  static getPattern() {
+  getPattern() {
     return {
       pathPatterns: [
         '.vimrc$',
@@ -37,9 +38,9 @@ export default class Vim {
         'highlight-source-viml',
       ],
     };
-  }
+  },
 
-  static getLinkRegexes() {
+  getLinkRegexes() {
     return VIM_PLUGIN;
-  }
-}
+  },
+};

--- a/test/load-plugins.test.js
+++ b/test/load-plugins.test.js
@@ -2,13 +2,17 @@ import assert from 'assert';
 import loadPlugins from '../lib/load-plugins.js';
 
 describe('load-plugins', () => {
-  it('returns an array of functions', () => {
+  it('returns an array of objects', () => {
     const plugins = loadPlugins();
 
     assert(Array.isArray(plugins));
 
-    plugins.forEach((func) => {
-      assert.equal(typeof func, 'function');
+    plugins.forEach((plugin) => {
+      assert.equal(typeof plugin, 'object');
+      assert(plugin.name);
+      assert(plugin.resolve);
+      assert(plugin.getPattern);
+      assert(plugin.parseBlob || plugin.getLinkRegexes);
     });
   });
 });


### PR DESCRIPTION
As mentioned in https://github.com/OctoLinker/browser-extension/pull/341#issuecomment-293080486,
this lets us avoid unnecessarily instantiating the class, and just use
the plugin directly instead.