### PR TITLE
homebrew: Add `.rb` extension to target

### DIFF
--- a/lib/plugins/homebrew-manifest.js
+++ b/lib/plugins/homebrew-manifest.js
@@ -6,6 +6,7 @@ export default {
   name: 'Homebrew',
 
   resolve({ path, target }) {
+    target += '.rb';
     return [
       relativeFile({ path, target }),
       `https://github.com/Homebrew/homebrew-core/blob/master/Formula/${target}`,

--- a/test/plugins/homebrew-manifest.test.js
+++ b/test/plugins/homebrew-manifest.test.js
@@ -6,7 +6,7 @@ describe('homebrew-file', () => {
     assert.deepEqual(
       homebrew.resolve({
         path: '/Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/octave.rb',
-        target: 'autoconf.rb',
+        target: 'autoconf',
       }),
       [
         '{BASE_URL}/Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/autoconf.rb',


### PR DESCRIPTION
Test page: https://github.com//Homebrew/homebrew-science/blob/1acf4f470fc8c87f6bcbf19b721ebcd09c7fb025/octave.rb#L44