### PR TITLE
vim: Use `target` argument instead of `shorthand`

### DIFF
--- a/lib/plugins/vim.js
+++ b/lib/plugins/vim.js
@@ -5,21 +5,21 @@ import { VIM_PLUGIN } from '../../packages/helper-grammar-regex-collection/index
 export default {
   name: 'Vim',
 
-  resolve({ shorthand }) {
+  resolve({ target }) {
     // Logic adapted from https://github.com/VundleVim/Vundle.vim/blob/11fdc428fe741f4f6974624ad76ab7c2b503b73e/doc/vundle.txt#L196
-    const components = shorthand.split('/');
+    const components = target.split('/');
 
     // GitHub is used when a user/repo is passed to `Plugin`.
     if (components.length === 2) {
-      return ghShorthand(shorthand, true);
+      return ghShorthand(target, true);
     }
     // Any single word without a slash '/' is assumed to be from Vim Scripts.
     if (components.length === 1) {
-      return ghShorthand(`vim-scripts/${shorthand}`, true);
+      return ghShorthand(`vim-scripts/${target}`, true);
     }
     // Assume it's a URL otherwise. We can't link to git/ssh, so change to https
     // and hope it works.
-    return giturl.parse(shorthand);
+    return giturl.parse(target);
   },
 
   getPattern() {

--- a/test/plugins/vim.test.js
+++ b/test/plugins/vim.test.js
@@ -4,21 +4,21 @@ import vimPlugin from '../../lib/plugins/vim';
 describe('vim-plugin', () => {
   it('resolves VundleVim/Vundle.vim to https://github.com/VundleVim/Vundle.vim', () => {
     assert.deepEqual(
-      vimPlugin.resolve({ shorthand: 'VundleVim/Vundle.vim' }),
+      vimPlugin.resolve({ target: 'VundleVim/Vundle.vim' }),
       'https://github.com/VundleVim/Vundle.vim',
     );
   });
 
   it('resolves ctrlp.vim to https://github.com/vim-scripts/ctrlp.vim', () => {
     assert.deepEqual(
-      vimPlugin.resolve({ shorthand: 'ctrlp.vim' }),
+      vimPlugin.resolve({ target: 'ctrlp.vim' }),
       'https://github.com/vim-scripts/ctrlp.vim',
     );
   });
 
   it('resolves a git:// URL to https/http', () => {
     assert.deepEqual(
-      vimPlugin.resolve({ shorthand: 'git://git.wincent.com/command-t.git' }),
+      vimPlugin.resolve({ target: 'git://git.wincent.com/command-t.git' }),
       'http://git.wincent.com/command-t',
     );
   });


### PR DESCRIPTION
Commit 9750462 accidentally broke vimrc support, but this fixes it.

Test page: https://github.com/gmarik/vimfiles/blob/1f4f26d42f54443f1158e0009746a56b9a28b053/vimrc#L140-L144