### PR TITLE
Upgrade `xregexp` to v3.2.0, remove 'x' flag workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "semver": "^5.3.0",
     "semver-regex": "^1.0.0",
     "uuid": "^3.0.1",
-    "xregexp": "^3.1.1"
+    "xregexp": "^3.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.22.1",

--- a/packages/helper-grammar-regex-collection/regex.js
+++ b/packages/helper-grammar-regex-collection/regex.js
@@ -16,9 +16,7 @@ function interpolate(substitution) {
 // http://xregexp.com/api/#build
 export default function (literals, ...substitutions) {
   const flags = 'xngm';
-  // the 'x' flag doesn't seem to work if we pass it outside the pattern
-  // so put it inside as well
-  let buildPattern = flags.includes('x') ? '(?x)' : '';
+  let buildPattern = '';
   const subpatterns = [];
 
   // make `substitutions` the same length as `literals`

--- a/yarn.lock
+++ b/yarn.lock
@@ -5537,9 +5537,9 @@ xmlhttprequest-ssl@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz#185a888c04eca46c3e4070d99f7b49de3528992d"
 
-xregexp@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-3.1.1.tgz#8ee18d75ef5c7cb3f9967f8d29414a6ca5b1a184"
+xregexp@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-3.2.0.tgz#cb3601987bfe2695b584000c18f1c4a8c322878e"
 
 xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
https://github.com/slevithan/xregexp/issues/162 has been fixed in
`xregexp` v3.2.0, so we don't have to work around it anymore.