### PR TITLE
Inline babel helpers rather than requiring them

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
       [
         "transform-runtime",
         {
+          "helpers": false,
           "polyfill": false
         }
       ],


### PR DESCRIPTION
This addresses https://github.com/OctoLinker/browser-extension/issues/351
by removing a couple of `Function()` calls from `dist/app.js`. Here's
the diff in the output of `grep ' Function(' dist/app.js`:

```diff
diff --git a/before.txt b/after.txt
index cfc9de2..c5c2ee1 100644
--- a/before.txt
+++ b/after.txt
@@ -1,4 +1,2 @@
-  ? window : typeof self != 'undefined' && self.Math == Math ? self : Function('return this')();
 	g = g || Function("return this")() || (1,eval)("this");
-      invoke(typeof fn == 'function' ? fn : Function(fn), args);
   ? window : typeof self != 'undefined' && self.Math == Math ? self : Function('return this')();
```

Hopefully, the remaining two calls will be ok, since they simply get the
global object, rather than have the potential to execute arbitrary code.

EDIT: See here for more info about the `helpers` option: https://github.com/babel/babel/tree/412180e20304347f8c402f7e3c0613951ac5144c/packages/babel-plugin-transform-runtime#helpers