### PR TITLE
Note support for Ruby `require_relative` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ OctoLinker is the easiest and best way to navigate between files and projects on
 
 ### Ruby
 - `require`
+- `require_relative`
 
 ### Rubygems
 - `gem`


### PR DESCRIPTION
As [`browser-extension/packages/helper-grammar-regex-collection/index.js` line 15](https://github.com/OctoLinker/browser-extension/blob/7a12c2665ba5d5999d6cb4786449eef996d33b91/packages/helper-grammar-regex-collection/index.js#L15) shows, `require_relative` is supported – it just isn't mentioned in the README. Before looking that up I assumed from the README that this extension didn't support that keyword.