### PR TITLE
Remove non-URL-safe characters from npm package names

### DIFF
--- a/lib/plugins/javascript.js
+++ b/lib/plugins/javascript.js
@@ -66,6 +66,8 @@ export default {
       return javascriptFile({ target, path });
     }
 
+    target = target.replace(/[^\w-.!~*'()@/]/g, '');
+
     // If the target looks like 'foo/bar.js', pretend it is 'foo' instead. See
     // https://github.com/OctoLinker/browser-extension/issues/93
     const topModuleName = getTopModuleName(target);

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -6,6 +6,10 @@ import * as REGEX from './index.js';
 const fixtures = {
   IMPORT: {
     valid: [
+      // See https://github.com/OctoLinker/browser-extension/issues/338#issuecomment-306065970
+      ["* import {Component, NgZone} from '\\@angular/core';", ['\\@angular/core']],
+      ["* import {NgIf} from '\\@angular/common';", ['\\@angular/common']],
+
       'import foo from "foo"',
       'import _ from "foo"',
       'import $ from "foo"',


### PR DESCRIPTION
This makes it possible to link package names that are escaped, due to being
in JSdoc-style comments, for example:
https://github.com/angular/core-builds/blob/85cbe3f8d6107af033b0f8b56456c181cbcb5eb7/%40angular/core.js#L3260

From https://docs.npmjs.com/files/package.json#name:

> The name ends up being part of a URL, an argument on the command line,
> and a folder name. Therefore, the name can't contain any non-URL-safe
> characters.

From https://devdocs.io/javascript/global_objects/encodeuricomponent:

> `encodeURIComponent` escapes all characters except the following:
> alphabetic, decimal digits, `- _ . ! ~ * ' ( )`

Additionally, '@' and '/' are allowed, since they are part of scoped
package names.

This addresses https://github.com/OctoLinker/browser-extension/issues/338