### PR TITLE
Fix .net core parsing for framework-specific dependencies

### DIFF
--- a/lib/plugins/dot-net-core.js
+++ b/lib/plugins/dot-net-core.js
@@ -31,6 +31,7 @@ export default {
     processJSON(blob, {
       '$.dependencies': linkDependency,
       '$.tools': linkDependency,
+      '$.frameworks.*.dependencies': linkDependency
     });
   },
 };

--- a/lib/plugins/dot-net-core.js
+++ b/lib/plugins/dot-net-core.js
@@ -31,7 +31,7 @@ export default {
     processJSON(blob, {
       '$.dependencies': linkDependency,
       '$.tools': linkDependency,
-      '$.frameworks.*.dependencies': linkDependency
+      '$.frameworks.*.dependencies': linkDependency,
     });
   },
 };

--- a/lib/plugins/helper/process-json.js
+++ b/lib/plugins/helper/process-json.js
@@ -4,7 +4,8 @@ export default function (blob, config) {
   const json = blob.toJSON();
 
   Object.entries(config).map(([path, linker]) => {
-    const result = jsonPath({ json, path, resultType: 'all' })[0];
+    const jsonResult = jsonPath({ json, path, resultType: 'all' });
+    const result = jsonResult[0];
 
     if (!result) {
       return undefined;
@@ -14,8 +15,10 @@ export default function (blob, config) {
       return linker(blob, result.parentProperty, result.value);
     }
 
-    for (const [key, value] of Object.entries(result.value)) {
-      linker(blob, key, value);
+    for (const node of jsonResult) {
+      for (const [key, value] of Object.entries(node.value)) {
+        linker(blob, key, value);
+      }
     }
   });
 }


### PR DESCRIPTION
The extension doesn't parse framework-specific dependencies in project.json file.
Here is an example of such file:
https://github.com/olsh/todoist-net/blob/master/src/Todoist.Net.Tests/project.json (lines 13 and 21)