### PR TITLE
Update github-injection to latest version

### DIFF
--- a/lib/octo-linker.js
+++ b/lib/octo-linker.js
@@ -54,6 +54,6 @@ export default class OctoLinkerCore {
   }
 
   init() {
-    injection(window, run.bind(null, this));
+    injection(run.bind(null, this));
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "core-js": "^2.4.1",
     "escape-regex-string": "^1.0.4",
     "findandreplacedomtext": "^0.4.5",
-    "github-injection": "^0.3.0",
+    "github-injection": "^1.0.1",
     "github-url-from-git": "^1.5.0",
     "github-url-from-username-repo": "^1.0.2",
     "giturl": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2516,9 +2516,9 @@ git-rev-sync@1.8.0:
     graceful-fs "4.1.6"
     shelljs "0.7.4"
 
-github-injection@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/github-injection/-/github-injection-0.3.0.tgz#04382fb4b820f0e38effb6644b47461693504a9f"
+github-injection@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/github-injection/-/github-injection-1.0.1.tgz#fad4bee67b988993c527556101a87138245ed0dc"
 
 github-url-from-git@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
This PR updates `github-injection` to make use of the latest improvements see https://github.com/OctoLinker/injection/releases