### PR TITLE
Support commit-ish in package.json

### DIFF
--- a/lib/plugins/npm-manifest.js
+++ b/lib/plugins/npm-manifest.js
@@ -42,8 +42,8 @@ export default {
     }
 
     return [
-      gitUrl({ target }),
       githubShorthand({ target }),
+      gitUrl({ target }),
     ];
   },
 

--- a/lib/resolver/github-shorthand.js
+++ b/lib/resolver/github-shorthand.js
@@ -1,5 +1,5 @@
 import ghShorthand from 'github-url-from-username-repo';
 
 export default function ({ target }) {
-  return ghShorthand(target, true);
+  return ghShorthand(target.replace(/^https:\/\/github.com\//, ''), true);
 }


### PR DESCRIPTION
Demo: https://github.com/josephfrazier/prettier_d/blob/3319ee19d8d9bcd12a10e3b84dfbc96b702af6e5/package.json#L44

Before: `prettier` link goes to https://github.com/josephfrazier/prettier#cosmiconfig-master-branch

After: `prettier` link goes to https://github.com/josephfrazier/prettier/tree/cosmiconfig-master-branch

Fixes https://github.com/OctoLinker/browser-extension/issues/374

See https://github.com/robertkowalski/github-url-from-username-repo/commit/534faff3e1645e61eb80da84885226800c6bf2ff