### PR TITLE
Handle HTML script tags

### DIFF
--- a/lib/plugins/html.js
+++ b/lib/plugins/html.js
@@ -1,4 +1,7 @@
-import { HTML_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
+import {
+  HTML_IMPORT,
+  HTML_SCRIPT_IMPORT,
+} from '../../packages/helper-grammar-regex-collection/index.js';
 import relativeFile from '../resolver/relative-file.js';
 
 export default {
@@ -16,6 +19,6 @@ export default {
   },
 
   getLinkRegexes() {
-    return HTML_IMPORT;
+    return [HTML_IMPORT, HTML_SCRIPT_IMPORT];
   },
 };

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -131,18 +131,12 @@ export const HTML_IMPORT = regex`
   href=${captureQuotedWord}>
 `;
 
-// handles the case the HTML script tag has a type with it
-const typeRegex = regex`
-  (\stype=['"][^'"\s]+['"])?
-`;
-
 export const HTML_SCRIPT_IMPORT = regex`
-  ^\s*
   <script
-  ${typeRegex}
+  [^>]"
   \s
   src=${captureQuotedWord}
-  ${typeRegex}
+  [^>]"
   \s*>
 `;
 

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -133,10 +133,10 @@ export const HTML_IMPORT = regex`
 
 export const HTML_SCRIPT_IMPORT = regex`
   <script
-  [^>]"
+  [^>]*
   \s
   src=${captureQuotedWord}
-  [^>]"
+  [^>]*
   \s*>
 `;
 

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -131,6 +131,21 @@ export const HTML_IMPORT = regex`
   href=${captureQuotedWord}>
 `;
 
+// handles the case the HTML script tag has a type with it
+const typeRegex = regex`
+  (\stype=['"][^'"\s]+['"])?
+`;
+
+export const HTML_SCRIPT_IMPORT = regex`
+  ^\s*
+  <script
+  ${typeRegex}
+  \s
+  src=${captureQuotedWord}
+  ${typeRegex}
+  \s*>
+`;
+
 export const NET_PACKAGE = regex`
   <\s*
   package

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -312,6 +312,22 @@ const fixtures = {
     valid: ['<link rel="import" href="foo">'],
     invalid: ['<link href="foo">'],
   },
+  HTML_SCRIPT_IMPORT: {
+    valid: [
+      '<script src="foo"></script>',
+      `<script src="foo">
+        function bar() {}
+      </script>`,
+      '<script type="application/javascript" src="foo"></script>',
+      '<script src="foo" type="application/javascript"></script>',
+    ],
+    invalid: [
+      '<script></script>',
+      `<script>
+        function bar() {}
+      </script>`,
+    ],
+  },
   go: {
     valid: [
       'import "foo"',


### PR DESCRIPTION
Closes #382 

Basic handling of `<script src="myfile.js"></script>`. See the new tests for a full breakdown of what I've handled.

While I was doing this, I noticed that absolute URL sources, such as on a CDN or similar, do not work with this. I can't see it being super useful, but what are your thoughts on putting something like:

```js
if (/^(https?:)?\/\//.test(target)) {
  return [target];
}
```

in the `resolve` function so that the absolute URLs open up where they target.