### PR TITLE
fixes tooltip remaining as `redirecting` after opening link in new tab

### DIFF
--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -12,25 +12,21 @@ const $body = $('body');
 let pluginManager;
 
 function openUrl(url, newWindow = false, newWindowActive = true) {
-  return new Promise(async resolve => {
-    if (!url) {
-      resolve();
-      return;
-    }
+  if (!url) {
+    return;
+  }
 
-    if (newWindow) {
-      await chrome.runtime.sendMessage({
-        type: 'newTab',
-        payload: {
-          url,
-          active: newWindowActive,
-        },
-      });
-      resolve();
-    } else {
-      window.location.href = url;
-    }
-  });
+  if (newWindow) {
+    chrome.runtime.sendMessage({
+      type: 'newTab',
+      payload: {
+        url,
+        active: newWindowActive,
+      },
+    });
+  } else {
+    window.location.href = url;
+  }
 }
 
 function getResolverUrls(dataAttr) {
@@ -121,7 +117,7 @@ async function onClick(event) {
       event.ctrlKey ||
       event.which === 2;
     const newWindowActive = storage.get('newWindowActive');
-    await openUrl((res || {}).url || url, newWindow, newWindowActive);
+    openUrl((res || {}).url || url, newWindow, newWindowActive);
     removeTooltip($tooltipTarget);
   } catch (err) {
     track('error');

--- a/lib/click-handler.js
+++ b/lib/click-handler.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import { showTooltip } from './gh-interface.js';
+import { showTooltip, removeTooltip } from './gh-interface.js';
 import * as storage from './options/storage.js';
 import fetch from './utils/fetch.js';
 
@@ -12,21 +12,25 @@ const $body = $('body');
 let pluginManager;
 
 function openUrl(url, newWindow = false, newWindowActive = true) {
-  if (!url) {
-    return;
-  }
+  return new Promise(async resolve => {
+    if (!url) {
+      resolve();
+      return;
+    }
 
-  if (newWindow) {
-    chrome.runtime.sendMessage({
-      type: 'newTab',
-      payload: {
-        url,
-        active: newWindowActive,
-      },
-    });
-  } else {
-    window.location.href = url;
-  }
+    if (newWindow) {
+      await chrome.runtime.sendMessage({
+        type: 'newTab',
+        payload: {
+          url,
+          active: newWindowActive,
+        },
+      });
+      resolve();
+    } else {
+      window.location.href = url;
+    }
+  });
 }
 
 function getResolverUrls(dataAttr) {
@@ -117,7 +121,8 @@ async function onClick(event) {
       event.ctrlKey ||
       event.which === 2;
     const newWindowActive = storage.get('newWindowActive');
-    openUrl((res || {}).url || url, newWindow, newWindowActive);
+    await openUrl((res || {}).url || url, newWindow, newWindowActive);
+    removeTooltip($tooltipTarget);
   } catch (err) {
     track('error');
     showTooltip($tooltipTarget, SORRY);

--- a/lib/gh-interface.js
+++ b/lib/gh-interface.js
@@ -8,6 +8,14 @@ export function showTooltip($target, msg) {
   $target.attr('aria-label', msg);
 }
 
+export function removeTooltip($target) {
+  if ($target.hasClass('tooltipped')) {
+    $target.removeClass('tooltipped tooltipped-e');
+  }
+
+  $target.removeAttr('aria-label');
+}
+
 export function showNotification({ description, version, url }) {
   const html = `<div class="flash flash-full">
     <div class="container">


### PR DESCRIPTION
### fixes #384 
- fixes tooltip remaining as `Redirecting  🚀` even after opening link in new tab
- adds `removeTooltip` function in `gh-interface.js` 
---------
Thank you for making this amazing extension. :clinking_glasses: 