### PR TITLE
Add a little Java support

### DIFF
--- a/lib/plugins/java.js
+++ b/lib/plugins/java.js
@@ -1,0 +1,31 @@
+import { JAVA_IMPORT } from '../../packages/helper-grammar-regex-collection/index.js';
+
+const SUPPORTED_JAVA_VERSIONS = [9, 8, 7];
+
+export default {
+  name: 'Java',
+
+  resolve({ target }) {
+    const targetAsPath = target.replace(/\./g, '/');
+
+    return SUPPORTED_JAVA_VERSIONS.reduce(
+      (memo, version) =>
+        memo.concat(
+          `https://docs.oracle.com/javase/${version}/docs/api/${targetAsPath}.html`,
+          `https://docs.oracle.com/javaee/${version}/api/${targetAsPath}.html`,
+        ),
+      [],
+    );
+  },
+
+  getPattern() {
+    return {
+      pathPatterns: ['.java$'],
+      githubClasses: ['type-java', 'highlight-source-java'],
+    };
+  },
+
+  getLinkRegexes() {
+    return JAVA_IMPORT;
+  },
+};

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -147,3 +147,13 @@ export const NET_PACKAGE = regex`
   id=${captureQuotedWord}
   .*/>
 `;
+
+export const JAVA_IMPORT = regex`
+  ^\s*
+  import
+  \s
+  (?<$1>
+    javax? # For now, we support java core packages only
+    ((\.[a-zA-Z0-9_]+)+[a-zA-Z0-9_])*
+  )
+`;

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -385,6 +385,21 @@ const fixtures = {
       '<package version="2.7.7.02" targetFramework="net45" />',
     ],
   },
+  JAVA_IMPORT: {
+    valid: [
+      ['import java.util.Foo', ['java.util.Foo']],
+      ['import javax.util.Foo', ['javax.util.Foo']],
+    ],
+    invalid: [
+      'import com.company.app', // For now, we support java core packages only
+      'import 1com.company.myapp',
+      'import m.company.region.myapp',
+      'import c0m.company.region.myapp',
+      'import com.-company.myapp',
+      'import com.company.1',
+      'import com.company..myapp',
+    ],
+  },
 };
 
 function fixturesIterator(fixturesList, next) {

--- a/test/plugins/java.test.js
+++ b/test/plugins/java.test.js
@@ -1,0 +1,15 @@
+import assert from 'assert';
+import Java from '../../lib/plugins/java';
+
+describe('Java', () => {
+  it('resolves java core links', () => {
+    assert.deepEqual(Java.resolve({ target: 'java.util.Foo' }), [
+      `https://docs.oracle.com/javase/9/docs/api/java/util/Foo.html`,
+      `https://docs.oracle.com/javaee/9/api/java/util/Foo.html`,
+      `https://docs.oracle.com/javase/8/docs/api/java/util/Foo.html`,
+      `https://docs.oracle.com/javaee/8/api/java/util/Foo.html`,
+      `https://docs.oracle.com/javase/7/docs/api/java/util/Foo.html`,
+      `https://docs.oracle.com/javaee/7/api/java/util/Foo.html`,
+    ]);
+  });
+});


### PR DESCRIPTION
Adding full support for Java isn't an easy task. After many nights working on this over the last couple of months, I decided to start with a simple version as a MVF minimum viable feature 😉 

As a first step, OctoLinker links java SE and EE imports to their documentation page. It doesn't take the version set in the pom.xml into account. Instead, OctoLinker tries to find the class either in SE/EE version 9, 8 and last but not least 7. 

### Demo
https://github.com/spring-projects/spring-framework/blob/master/spring-context/src/main/java/org/springframework/ui/Model.java#L19

### Preview
![Java](https://user-images.githubusercontent.com/1393946/32469182-c9851a2a-c351-11e7-9ab1-cee227aec812.gif)
