### PR TITLE
Convert pathPatterns to RegExp to ensure proper escaping

### DIFF
--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -20,7 +20,7 @@ function buildPluginCache(plugins) {
   const lookup = new Map();
 
   plugins.forEach(plugin => {
-    plugin.getPattern().pathPatterns.forEach(pattern => {
+    plugin.getPattern().pathRegexes.forEach(pattern => {
       updatePluginsForKey(lookup, plugin, pattern);
     });
 

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -21,7 +21,7 @@ function buildPluginCache(plugins) {
 
   plugins.forEach(plugin => {
     plugin.getPattern().pathPatterns.forEach(pattern => {
-      updatePluginsForKey(lookup, plugin, RegExp(pattern));
+      updatePluginsForKey(lookup, plugin, pattern);
     });
 
     if (!plugin.getPattern().githubClasses) {

--- a/lib/plugins/bower-manifest.js
+++ b/lib/plugins/bower-manifest.js
@@ -46,7 +46,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/bower\.json$/],
+      pathRegexes: [/bower\.json$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/bower-manifest.js
+++ b/lib/plugins/bower-manifest.js
@@ -46,7 +46,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['/bower.json$'],
+      pathPatterns: [/bower\.json$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/composer-manifest.js
+++ b/lib/plugins/composer-manifest.js
@@ -25,7 +25,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/composer\.json$/],
+      pathRegexes: [/composer\.json$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/composer-manifest.js
+++ b/lib/plugins/composer-manifest.js
@@ -25,7 +25,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['/composer.json$'],
+      pathPatterns: [/composer\.json$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/css.js
+++ b/lib/plugins/css.js
@@ -10,7 +10,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/\.css$/],
+      pathRegexes: [/\.css$/],
       githubClasses: ['type-css', 'highlight-source-css'],
     };
   },

--- a/lib/plugins/css.js
+++ b/lib/plugins/css.js
@@ -10,7 +10,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['.css$'],
+      pathPatterns: [/\.css$/],
       githubClasses: ['type-css', 'highlight-source-css'],
     };
   },

--- a/lib/plugins/docker.js
+++ b/lib/plugins/docker.js
@@ -16,7 +16,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['/Dockerfile$'],
+      pathPatterns: [/Dockerfile$/],
       githubClasses: ['type-dockerfile', 'highlight-source-dockerfile'],
     };
   },

--- a/lib/plugins/docker.js
+++ b/lib/plugins/docker.js
@@ -16,7 +16,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/Dockerfile$/],
+      pathRegexes: [/Dockerfile$/],
       githubClasses: ['type-dockerfile', 'highlight-source-dockerfile'],
     };
   },

--- a/lib/plugins/dot-net-core.js
+++ b/lib/plugins/dot-net-core.js
@@ -21,7 +21,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/project\.json$/],
+      pathRegexes: [/project\.json$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/dot-net-core.js
+++ b/lib/plugins/dot-net-core.js
@@ -21,7 +21,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['/project.json$'],
+      pathPatterns: [/project\.json$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/dot-net.js
+++ b/lib/plugins/dot-net.js
@@ -10,7 +10,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/packages\.config$/],
+      pathRegexes: [/packages\.config$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/dot-net.js
+++ b/lib/plugins/dot-net.js
@@ -10,7 +10,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['/packages.config$'],
+      pathPatterns: [/packages\.config$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/gemfile-manifest.js
+++ b/lib/plugins/gemfile-manifest.js
@@ -13,7 +13,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/Gemfile$/],
+      pathRegexes: [/Gemfile$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/gemfile-manifest.js
+++ b/lib/plugins/gemfile-manifest.js
@@ -13,7 +13,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['/Gemfile$'],
+      pathPatterns: [/Gemfile$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/go.js
+++ b/lib/plugins/go.js
@@ -52,7 +52,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['.go$'],
+      pathPatterns: [/\.go$/],
       githubClasses: ['type-go', 'highlight-source-go'],
     };
   },

--- a/lib/plugins/go.js
+++ b/lib/plugins/go.js
@@ -52,7 +52,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/\.go$/],
+      pathRegexes: [/\.go$/],
       githubClasses: ['type-go', 'highlight-source-go'],
     };
   },

--- a/lib/plugins/haskell.js
+++ b/lib/plugins/haskell.js
@@ -21,7 +21,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['.hs$'],
+      pathPatterns: [/\.hs$/],
       githubClasses: ['type-haskell'],
     };
   },

--- a/lib/plugins/haskell.js
+++ b/lib/plugins/haskell.js
@@ -21,7 +21,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/\.hs$/],
+      pathRegexes: [/\.hs$/],
       githubClasses: ['type-haskell'],
     };
   },

--- a/lib/plugins/html.js
+++ b/lib/plugins/html.js
@@ -13,7 +13,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/\.html?$/],
+      pathRegexes: [/\.html?$/],
       githubClasses: ['type-html'],
     };
   },

--- a/lib/plugins/html.js
+++ b/lib/plugins/html.js
@@ -13,7 +13,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['.html$', '.htm$'],
+      pathPatterns: [/\.html?$/],
       githubClasses: ['type-html'],
     };
   },

--- a/lib/plugins/java.js
+++ b/lib/plugins/java.js
@@ -20,7 +20,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['.java$'],
+      pathPatterns: [/\.java$/],
       githubClasses: ['type-java', 'highlight-source-java'],
     };
   },

--- a/lib/plugins/java.js
+++ b/lib/plugins/java.js
@@ -20,7 +20,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/\.java$/],
+      pathRegexes: [/\.java$/],
       githubClasses: ['type-java', 'highlight-source-java'],
     };
   },

--- a/lib/plugins/javascript.js
+++ b/lib/plugins/javascript.js
@@ -88,11 +88,10 @@ export default {
   getPattern() {
     return {
       pathPatterns: [
-        '.js$',
-        '.jsx$',
-        '.es6$',
+        /\.jsx?$/,
+        /\.es6$/,
         // CoffeeScript
-        '.coffee$',
+        /\.coffee$/,
       ],
       githubClasses: [
         'type-javascript',

--- a/lib/plugins/javascript.js
+++ b/lib/plugins/javascript.js
@@ -87,7 +87,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [
+      pathRegexes: [
         /\.jsx?$/,
         /\.es6$/,
         // CoffeeScript

--- a/lib/plugins/less.js
+++ b/lib/plugins/less.js
@@ -11,7 +11,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/\.less$/],
+      pathRegexes: [/\.less$/],
       githubClasses: ['type-less', 'highlight-source-css-less'],
     };
   },

--- a/lib/plugins/less.js
+++ b/lib/plugins/less.js
@@ -11,7 +11,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['.less$'],
+      pathPatterns: [/\.less$/],
       githubClasses: ['type-less', 'highlight-source-css-less'],
     };
   },

--- a/lib/plugins/nodejs-relative-path.js
+++ b/lib/plugins/nodejs-relative-path.js
@@ -14,14 +14,14 @@ export default {
   },
 
   getPattern() {
-    const jsPatterns = JavaScript.getPattern().pathPatterns;
-    const tsPatterns = TypeScript.getPattern().pathPatterns;
+    const jsRegexes = JavaScript.getPattern().pathRegexes;
+    const tsRegexes = TypeScript.getPattern().pathRegexes;
 
     const jsClasses = JavaScript.getPattern().githubClasses;
     const tsClasses = TypeScript.getPattern().githubClasses;
 
     return {
-      pathPatterns: jsPatterns.concat(tsPatterns),
+      pathRegexes: jsRegexes.concat(tsRegexes),
       githubClasses: jsClasses.concat(tsClasses),
     };
   },

--- a/lib/plugins/npm-manifest.js
+++ b/lib/plugins/npm-manifest.js
@@ -46,7 +46,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['/package.json$'],
+      pathPatterns: [/package\.json$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/npm-manifest.js
+++ b/lib/plugins/npm-manifest.js
@@ -46,7 +46,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/package\.json$/],
+      pathRegexes: [/package\.json$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/python.js
+++ b/lib/plugins/python.js
@@ -35,7 +35,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['.py$'],
+      pathPatterns: [/\.py$/],
       githubClasses: ['type-python', 'highlight-source-python'],
     };
   },

--- a/lib/plugins/python.js
+++ b/lib/plugins/python.js
@@ -35,7 +35,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/\.py$/],
+      pathRegexes: [/\.py$/],
       githubClasses: ['type-python', 'highlight-source-python'],
     };
   },

--- a/lib/plugins/requirements-txt.js
+++ b/lib/plugins/requirements-txt.js
@@ -15,7 +15,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/requirements\.txt$/],
+      pathRegexes: [/requirements\.txt$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/requirements-txt.js
+++ b/lib/plugins/requirements-txt.js
@@ -15,7 +15,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['requirements.txt$'],
+      pathPatterns: [/requirements\.txt$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/ruby.js
+++ b/lib/plugins/ruby.js
@@ -21,7 +21,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/\.rb$/],
+      pathRegexes: [/\.rb$/],
       githubClasses: ['type-ruby', 'highlight-source-ruby'],
     };
   },

--- a/lib/plugins/ruby.js
+++ b/lib/plugins/ruby.js
@@ -21,7 +21,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['.rb$'],
+      pathPatterns: [/\.rb$/],
       githubClasses: ['type-ruby', 'highlight-source-ruby'],
     };
   },

--- a/lib/plugins/rust.js
+++ b/lib/plugins/rust.js
@@ -10,7 +10,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/\.rs$/],
+      pathRegexes: [/\.rs$/],
       githubClasses: ['type-rust', 'highlight-source-rust'],
     };
   },

--- a/lib/plugins/rust.js
+++ b/lib/plugins/rust.js
@@ -10,7 +10,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['.rs$'],
+      pathPatterns: [/\.rs$/],
       githubClasses: ['type-rust', 'highlight-source-rust'],
     };
   },

--- a/lib/plugins/sass.js
+++ b/lib/plugins/sass.js
@@ -21,7 +21,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['.scss$', '.sass$'],
+      pathPatterns: [/\.s[c|a]ss$/],
       githubClasses: ['type-sass', 'highlight-source-sass'],
     };
   },

--- a/lib/plugins/sass.js
+++ b/lib/plugins/sass.js
@@ -21,7 +21,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/\.s[c|a]ss$/],
+      pathRegexes: [/\.s[c|a]ss$/],
       githubClasses: ['type-sass', 'highlight-source-sass'],
     };
   },

--- a/lib/plugins/typescript.js
+++ b/lib/plugins/typescript.js
@@ -8,7 +8,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: ['.ts$'],
+      pathPatterns: [/\.ts$/],
       githubClasses: ['type-typescript', 'highlight-source-ts'],
     };
   },

--- a/lib/plugins/typescript.js
+++ b/lib/plugins/typescript.js
@@ -8,7 +8,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [/\.ts$/],
+      pathRegexes: [/\.ts$/],
       githubClasses: ['type-typescript', 'highlight-source-ts'],
     };
   },

--- a/lib/plugins/vim.js
+++ b/lib/plugins/vim.js
@@ -24,7 +24,7 @@ export default {
 
   getPattern() {
     return {
-      pathPatterns: [
+      pathRegexes: [
         '.vimrc$',
         '.gvimrc$',
         '.vim$',


### PR DESCRIPTION
Today I noticed that some `pathPatterns` were wrong after converting the string into a RegExp. This was leading into loading the wrong plugin. Especially the escaping wasn't correct. For example `.css$` was converted to `/.css$/` where it should be `/\.css$/`. This PR is converting all `pathPatterns` string into a RegExp to ensure proper escaping.

