### PR TITLE
Drop core-js

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -8,9 +8,11 @@
   "icons": {
     "128": "icon.png"
   },
+  "minimum_chrome_version": "54",
   "applications": {
     "gecko": {
-      "id": "octolinker@stefanbuck.com"
+      "id": "octolinker@stefanbuck.com",
+      "strict_min_version": "47.0"
     }
   },
   "background": {

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,4 +1,3 @@
-import 'core-js/fn/object/entries';
 import OctoLinker from './octo-linker.js';
 import * as storage from './options/storage.js';
 import './app.css';

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "builtins": "^1.0.3",
     "chrome-promise": "^2.1.1",
     "concat-map": "^0.0.1",
-    "core-js": "^2.5.1",
     "css-loader": "^0.28.7",
     "escape-regex-string": "^1.0.4",
     "eslint-config-airbnb": "^16.0.0",

--- a/test/main-lib.js
+++ b/test/main-lib.js
@@ -1,5 +1,3 @@
-import 'core-js';
-
 window.chrome = {
   runtime: {
     sendMessage: () => {},


### PR DESCRIPTION
It's been supported for a while now, I'd argue that most babel transforms you have there are unnecessary. I think you probably exclusively need the JSX transform.