### PR TITLE
Update css selector to fix incorrect position of the permalink link

### DIFF
--- a/lib/app.css
+++ b/lib/app.css
@@ -31,8 +31,8 @@ a.octolinker-link {
 }
 
 /* Fix line indicator for issue code blocks */
-.highlight {
-  position: relative;;
+div.highlight {
+  position: relative;
 }
 
 .highlight .octolinker-line-indicator:after {


### PR DESCRIPTION
This resolves #391 by using a more specific css selector.