### PR TITLE
Release 4.14.0

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "OctoLinker",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "manifest_version": 2,
   "author": "Stefan Buck",
   "description": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "OctoLinker",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "engines": {
     "node": ">=6.0.0"
   },


### PR DESCRIPTION
Support for Java added and various bug fixes! 🚀

## Highlight

Do you know what's the second-most popular language on GitHub after JavaScript ... correct Java. Today we're happy to announce that OctoLinker is finally supporting a little Java. As a first step, OctoLinker links java SE and EE imports to their documentation page. It doesn't take the version set in the pom.xml into account. Instead, OctoLinker tries to find the class either in SE/EE version 9, 8 and last but not least 7.

![Java](https://user-images.githubusercontent.com/1393946/32469182-c9851a2a-c351-11e7-9ab1-cee227aec812.gif)

## Bugfixes

- Update css selector to fix incorrect position of the permalink link #396
- Fix a few broken plugins #392 

## All Changes

[v4.13.0...v4.14.0](https://github.com/OctoLinker/browser-extension/compare/v4.13.0...v4.14.0)

Huge thanks to our contributor: @bfred-it