### PR TITLE
.gitattributes: Force .js files to have LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto
+*.js text eol=lf
 packages/blob-reader/fixtures/* linguist-documentation


### PR DESCRIPTION
See https://help.github.com/articles/dealing-with-line-endings/

Addresses https://github.com/OctoLinker/browser-extension/pull/398#issuecomment-344091708