### PR TITLE
Support require calls using backtick-quoted strings in JS

### DIFF
--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -2,10 +2,20 @@ import regex from './regex';
 
 export { default as go } from './go.js';
 
+const captureWordInsideQuotes = regex`
+  (?<$1>[^'"\s]+) # capture the word inside the quotes
+`;
+
 const captureQuotedWord = regex`
   ['"]            # beginning quote
-  (?<$1>[^'"\s]+) # capture the word inside the quotes
+  ${captureWordInsideQuotes}
   ['"]            # end quote
+`;
+
+const captureJsQuotedWord = regex`
+  ['"\`]          # beginning quote
+  ${captureWordInsideQuotes}
+  ['"\`]          # end quote
 `;
 
 const importMembers = regex`[\r\n\s\w{},*\$]*`;
@@ -14,7 +24,7 @@ const from = regex`\s from \s`;
 export const NODEJS_RELATIVE_PATH = regex`
   __dirname
   \s* \+ \s*
-  ${captureQuotedWord}
+  ${captureJsQuotedWord}
 `;
 
 export const NODEJS_RELATIVE_PATH_JOIN = regex`
@@ -22,13 +32,13 @@ export const NODEJS_RELATIVE_PATH_JOIN = regex`
   \( \s*
   __dirname \s*
   , \s*
-  ${captureQuotedWord}
+  ${captureJsQuotedWord}
 `;
 
 export const REQUIRE = regex`
   ( require(\.resolve)? | proxyquire | import | require_relative )
   \s* ( \s | \( ) \s*
-  ${captureQuotedWord}
+  ${captureJsQuotedWord}
 `;
 
 export const IMPORT = regex`

--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -2,20 +2,16 @@ import regex from './regex';
 
 export { default as go } from './go.js';
 
-const captureWordInsideQuotes = regex`
-  (?<$1>[^'"\s]+) # capture the word inside the quotes
-`;
-
 const captureQuotedWord = regex`
-  ['"]            # beginning quote
-  ${captureWordInsideQuotes}
-  ['"]            # end quote
+  ['"]              # beginning quote
+  (?<$1>[^'"\s]+)   # capture the word inside the quotes
+  ['"]              # end quote
 `;
 
 const captureJsQuotedWord = regex`
-  ['"\`]          # beginning quote
-  ${captureWordInsideQuotes}
-  ['"\`]          # end quote
+  ['"\`]            # beginning quote
+  (?<$1>[^'"\`\s]+) # capture the word inside the quotes
+  ['"\`]            # end quote
 `;
 
 const importMembers = regex`[\r\n\s\w{},*\$]*`;

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -43,6 +43,7 @@ const fixtures = {
     ],
     invalid: [
       'import "fo o"',
+      'import foo from `foo`',
       // TODO tweak IMPORT regexp so that invalid statements are not matched
       // 'import foo "foo"',
       // 'import from "foo"',
@@ -58,7 +59,10 @@ const fixtures = {
       ['export { bar\n } from "foo"', ['foo']],
       ['export { \nbar\n } from "foo"', ['foo']],
     ],
-    invalid: ['export * from "fo o"'],
+    invalid: [
+      'export * from "fo o"',
+      'export * from `foo`',
+    ],
   },
   REQUIRE: {
     valid: [
@@ -79,6 +83,7 @@ const fixtures = {
       ['foo = require("foo")bar = require("bar")', ['foo', 'bar']],
       ['foo = require("a-b")bar = require("c-d-e")', ['a-b', 'c-d-e']],
       ['foo = require("./foo")bar = require("./bar")', ['./foo', './bar']],
+      ['foo = require(`./foo`)bar = require(`./bar`)', ['./foo', './bar']],
       [
         'const foo = require("./foo")bar = require("./bar")',
         ['./foo', './bar'],
@@ -93,6 +98,7 @@ const fixtures = {
       ['require.resolve(\t"foo"\t)', ['foo']],
       ['require.resolve ("foo")', ['foo']],
       ['var foo = require.resolve("foo")', ['foo']],
+      ['var foo = require.resolve(`foo`)', ['foo']],
       [
         'var foo = require.resolve("foo")var bar = require.resolve("bar")',
         ['foo', 'bar'],
@@ -120,7 +126,8 @@ const fixtures = {
       ['var _ = import("foo")', ['foo']],
       ['var foo = import("foo")var bar = import("bar")', ['foo', 'bar']],
       ['import("foo")import("bar");', ['foo', 'bar']],
-      ['import("foo")import("bar");', ['foo', 'bar']],
+      ['import("foo")import("bar")', ['foo', 'bar']],
+      ['import(`foo`)import(`bar`)', ['foo', 'bar']],
       ['var foo = import("foo")import("bar");', ['foo', 'bar']],
       ['var foo = import("foo")import("bar")', ['foo', 'bar']],
       ['foo = import("foo")import("bar")', ['foo', 'bar']],

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -59,10 +59,7 @@ const fixtures = {
       ['export { bar\n } from "foo"', ['foo']],
       ['export { \nbar\n } from "foo"', ['foo']],
     ],
-    invalid: [
-      'export * from "fo o"',
-      'export * from `foo`',
-    ],
+    invalid: ['export * from "fo o"', 'export * from `foo`'],
   },
   REQUIRE: {
     valid: [


### PR DESCRIPTION
Anywhere that a string literal can be used to import files in JS, backticks are valid:

```js
const someThing = require(`aw-yeah.js`)
```

This does not include ES Module imports/exports - those are restricted to single/double quotes.

I looked around for some tests to modify so I could add extra test cases, but I didn't see any tests that covered this - the tests in `test/grammar/` aren't being executed, and it looks like they were written for an older version of the library anyway.