### PR TITLE
Fix loading message by removing tooltip delay

### DIFF
--- a/lib/gh-interface.js
+++ b/lib/gh-interface.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 
 export function showTooltip($target, msg) {
   if (!$target.hasClass('tooltipped')) {
-    $target.addClass('tooltipped tooltipped-e');
+    $target.addClass('tooltipped tooltipped-e tooltipped-no-delay');
   }
 
   $target.attr('aria-label', msg);


### PR DESCRIPTION
Yesterday I noticed that the loading message (tooltip) doesn't work anymore. After looking at the documenation page of primer css (GitHub's ui component framework) it seems like they introduced a delay before showing a tooltip. This PR removes the delay to get instant feedback about the loading state