### PR TITLE
Handle leading whitespace in diff line

### DIFF
--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -15,7 +15,7 @@ const captureJsQuotedWord = regex`
 `;
 
 const diffSigns = regex`
-  ^[\+\-]?
+  ^[ \t]*[+-]?
 `;
 
 const importMembers = regex`[\r\n\s\w{},*\$]*`;

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -461,7 +461,7 @@ function fixturesIterator(fixturesList, next) {
 
 function addModifiedLines(valid) {
   const [text, expected] = valid[0];
-  const diffLines = [[`-${text}`, expected], [`+${text}`, expected]];
+  const diffLines = [[` -${text}`, expected], [` +${text}`, expected]];
 
   return [].concat([], diffLines, valid);
 }


### PR DESCRIPTION
#409 introduced a bug that stopped OctoLinker from inserting links. On GitHub a diff line starts with a whitespace character if the line is not modified which the RegeEx doesn't take into account. 

### Before
<img width="286" alt="screen shot 2017-12-06 at 23 44 30" src="https://user-images.githubusercontent.com/1393946/33689387-8bef4f00-dadf-11e7-955e-78a21b57db18.png">

### After
<img width="324" alt="screen shot 2017-12-06 at 23 43 48" src="https://user-images.githubusercontent.com/1393946/33689384-8aca78e8-dadf-11e7-8a3a-0e265f53e27d.png">
