### PR TITLE
Add cli tool support to .net proj files

### DIFF
--- a/packages/helper-grammar-regex-collection/index.js
+++ b/packages/helper-grammar-regex-collection/index.js
@@ -194,7 +194,7 @@ export const JAVA_IMPORT = regex`
 `;
 
 export const NET_PROJ_PACKAGE = regex`
-  <PackageReference
+  <(PackageReference|DotNetCliToolReference)
   \s+
   .*
   Include=${captureQuotedWord}

--- a/packages/helper-grammar-regex-collection/test.js
+++ b/packages/helper-grammar-regex-collection/test.js
@@ -441,11 +441,24 @@ const fixtures = {
         '<PackageReference Include="foo">\n<Version>2.0.0</Version>\n</PackageReference>',
         ['foo'],
       ],
+      ['<DotNetCliToolReference Include="foo" Version="6.2.0" />', ['foo']],
+      [
+        '<DotNetCliToolReference Include="foo" Version="$(MicrosoftExtensionsCachingMemoryPackageVersion)" />',
+        ['foo'],
+      ],
+      ['<DotNetCliToolReference Version="6.2.0" Include="foo" />', ['foo']],
+      [
+        '<DotNetCliToolReference Include="foo">\n<Version>2.0.0</Version>\n</DotNetCliToolReference>',
+        ['foo'],
+      ],
     ],
     invalid: [
       '<PackageReferences Include="EntityFramework" Version="6.2.0" />',
       '<PackageReference Includes="EntityFramework" Version="6.2.0" />',
       '< PackageReference Include="EntityFramework" Version="6.2.0" />',
+      '<DotNetCliToolReferences Include="Microsoft.DotNet.Xdt.Tools" Version="2.0.0" />',
+      '<DotNetCliToolReference Includes="Microsoft.DotNet.Xdt.Tools" Version="2.0.0" />',
+      '< DotNetCliToolReference  Include="Microsoft.DotNet.Xdt.Tools" Version="2.0.0" />',
     ],
   },
 };


### PR DESCRIPTION
This expands the existing .net proj file linking to also support [cli references](https://docs.microsoft.com/en-us/dotnet/core/tools/extensibility) via `DotNetCliToolReference`.

The tests are passing locally, but as per #418 I'm unable to build & test it myself 😞 

An example of where this would work is https://github.com/aspnet/DotNetTools/blob/3c20e7c45beb5d45547b549964a3da83b2e8303e/samples/dotnet-watch/LaunchAnyCommand/LaunchAnyCommand.csproj#L6-L10