### PR TITLE
Fix another loadPlugins-as-object usage

### DIFF
--- a/lib/octo-linker.js
+++ b/lib/octo-linker.js
@@ -5,7 +5,7 @@ import clickHandler from './click-handler';
 import Plugins from './plugin-manager.js';
 import insertLink from './insert-link';
 import debugMode from './debug-mode.js';
-import loadPlugins from './load-plugins';
+import * as loadPlugins from './load-plugins';
 import * as storage from './options/storage.js';
 
 function initialize(self) {
@@ -13,7 +13,7 @@ function initialize(self) {
   notification();
 
   self._blobReader = new BlobReader();
-  self._pluginManager = new Plugins(loadPlugins());
+  self._pluginManager = new Plugins(loadPlugins);
   clickHandler(self._pluginManager);
 }
 


### PR DESCRIPTION
Kudos to @xt0rted, see https://github.com/OctoLinker/browser-extension/issues/418#issuecomment-354213457

This wasn't included in e50f339 (https://github.com/OctoLinker/browser-extension/pull/415)