### PR TITLE
Add support for F# project files and .net props files

### DIFF
--- a/lib/plugins/dot-net.js
+++ b/lib/plugins/dot-net.js
@@ -13,7 +13,7 @@ export default {
 
   getPattern() {
     return {
-      pathRegexes: [/packages\.config$/, /\.(cs|vb)proj$/],
+      pathRegexes: [/packages\.config$/, /\.(cs|vb)proj$/, /\.props$/],
       githubClasses: [],
     };
   },

--- a/lib/plugins/dot-net.js
+++ b/lib/plugins/dot-net.js
@@ -13,7 +13,7 @@ export default {
 
   getPattern() {
     return {
-      pathRegexes: [/packages\.config$/, /\.(cs|vb)proj$/, /\.props$/],
+      pathRegexes: [/packages\.config$/, /\.(cs|fs|vb)proj$/, /\.props$/],
       githubClasses: [],
     };
   },


### PR DESCRIPTION
This adds support for F# project files which are the same xml format as those of C# & VB.Net. It also adds support for [props files](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build) which are used to extend them. MSBuild assumes a file name of `Directory.Build.props` but you can also manually import files of any name which commonly use the `.props` extension.

Sample F# project file
https://github.com/cartermp/GiraffeSample/blob/bbb8a0d3d08a31bf8d9ecac75457cd41953e8414/LunchAPI/LunchApi.fsproj

Example `.props` file without references
https://github.com/aspnet/Mvc/blob/747420e5aa7cc2c7834cfb9731510286ded6fc03/Directory.Build.props

Example `.props` file with references
https://github.com/aspnet/Mvc/blob/747420e5aa7cc2c7834cfb9731510286ded6fc03/src/Directory.Build.props

Example generic `.props` file with references
https://github.com/aspnet/DotNetTools/blob/d81f23e1599cd7c464ae51c3d5605c37b0421450/build/VSIX.props